### PR TITLE
Fix build issue when `__GNUC__ <= 2`

### DIFF
--- a/src/logerr.h
+++ b/src/logerr.h
@@ -34,7 +34,7 @@
 #if __GNUC__ > 2 || defined(__INTEL_COMPILER)
 #define	__printflike(a, b) __attribute__((format(printf, a, b)))
 #else
-#define	__printflike
+#define	__printflike(a, b)
 #endif
 #endif /* !__printflike */
 


### PR DESCRIPTION
The `__printflike` macro appears to take two arguments.