### PR TITLE
Wrap hook call in subshell

### DIFF
--- a/hooks/dhcpcd-run-hooks.in
+++ b/hooks/dhcpcd-run-hooks.in
@@ -346,6 +346,6 @@ do
 		esac
 	done
 	if [ -f "$hook" ]; then
-		. "$hook"
+		( . "$hook" )
 	fi
 done


### PR DESCRIPTION
Currently hooks are executed in the same shell. This means that if the hook script executes `exit`, subsequent hooks are not run. The man page doesn't document this behavior - indeed, it says all hooks are run. Wrapping in a subshell should avoid this. 

This is a behavior change. If it is anticipated that any users utilise this behavior, then it might not be possible to make this change so simply.