### PR TITLE
dhcpcd.8.in: Fix typos and minor grammatical issues

### DIFF
--- a/src/dhcpcd.8.in
+++ b/src/dhcpcd.8.in
@@ -22,7 +22,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd June 5, 2018
+.Dd September 3, 2018
 .Dt DHCPCD 8
 .Os
 .Sh NAME
@@ -102,7 +102,7 @@ sets the hostname to the one supplied by the DHCP server.
 .Nm
 then daemonises and waits for the lease renewal time to lapse.
 It will then attempt to renew its lease and reconfigure if the new lease
-changes when the lease beings to expire or the DHCP server sends message
+changes when the lease begins to expire or the DHCP server sends a message
 to renew early.
 .Pp
 If any interface reports a working carrier then
@@ -187,8 +187,8 @@ Using a single interface also affects the
 .Fl n
 and
 .Fl x
-options where the same interface will need to be specified as a lack of an
-interafce will imply Master mode which this is not.
+options, where the same interface will need to be specified, as a lack of an
+interface will imply Master mode which this is not.
 To force starting in Master mode with only one interface, the
 .Fl M , Fl Fl master
 option can be used.
@@ -272,10 +272,10 @@ If
 cannot obtain a lease, then try to use the last lease acquired for the
 interface.
 .It Fl Fl lastleaseextend
-Same as the above, but he lease will be retained even if it expires.
+Same as the above, but the lease will be retained even if it expires.
 .Nm
 will give it up if any other host tries to claim it for their own via ARP.
-This is does violate RFC2131 section 3.7 which states the lease should be
+This violates RFC2131 section 3.7, which states the lease should be
 dropped once it has expired.
 .It Fl e , Fl Fl env Ar value
 Push
@@ -322,7 +322,7 @@ If
 is an empty string then the current system hostname is sent.
 If
 .Ar hostname
-is a FQDN (ie, contains a .) then it will be encoded as such.
+is a FQDN (i.e., contains a .) then it will be encoded as such.
 .It Fl I , Fl Fl clientid Ar clientid
 Send the
 .Ar clientid .
@@ -483,7 +483,7 @@ then
 will not attempt to obtain a lease and just use the value for the address with
 an infinite lease time.
 .Pp
-Here is an example which configures a static address, routes and dns.
+Here is an example which configures a static address, routes and DNS.
 .D1 dhcpcd -S ip_address=192.168.0.10/24 \e
 .D1 -S routers=192.168.0.1 \e
 .D1 -S domain_name_servers=192.168.0.1 \e
@@ -788,11 +788,11 @@ Text file that holds a secret key known only to the host.
 .It Pa @DBDIR@/ Ns Ar interface Ns Ar -ssid Ns .lease
 The actual DHCP message sent by the server.
 We use this when reading the last
-lease and use the files mtime as when it was issued.
+lease and use the file's mtime as when it was issued.
 .It Pa @DBDIR@/ Ns Ar interface Ns Ar -ssid Ns .lease6
 The actual DHCPv6 message sent by the server.
 We use this when reading the last
-lease and use the files mtime as when it was issued.
+lease and use the file's mtime as when it was issued.
 .It Pa @DBDIR@/rdm_monotonic
 Stores the monotonic counter used in the
 .Ar replay


### PR DESCRIPTION
I noticed a few typos and such while reading this man page, so I thought I'd fix them. (Thanks for creating dhcpcd!)