### PR TITLE
30-hostname: Fix typo: hsort -> hshort

### DIFF
--- a/hooks/30-hostname
+++ b/hooks/30-hostname
@@ -80,7 +80,7 @@ need_hostname()
 	set_hostname_vars
 
 	if [ -n "$old_fqdn" ]; then
-		if ${hfqdn} || ! ${hsort}; then
+		if ${hfqdn} || ! ${hshort}; then
 			[ "$hostname" = "$old_fqdn" ]
 		else
 			[ "$hostname" = "${old_fqdn%%.*}" ]


### PR DESCRIPTION
I tried sending you the patch via email but it got rejected:

```
  roy@marples.name
    host dash.servers.dxld.at [82.199.155.50]
    SMTP error from remote mail server after RCPT TO:<roy@marples.name>:
    550 Administrative prohibition
```

Is that intentional or is my mail server config broken?