### PR TITLE
Use TAILQ_FOREACH_SAFE whenever we do TAILQ_REMOVE during traversal

### DIFF
--- a/src/eloop.c
+++ b/src/eloop.c
@@ -522,7 +522,7 @@ eloop_q_timeout_add_tv(struct eloop *eloop, int queue,
 	}
 
 	/* Remove existing timeout if present. */
-	TAILQ_FOREACH(t, &eloop->timeouts, next) {
+	TAILQ_FOREACH_SAFE(t, &eloop->timeouts, next, tt) {
 		if (t->callback == callback && t->arg == arg) {
 			TAILQ_REMOVE(&eloop->timeouts, t, next);
 			break;

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -487,7 +487,7 @@ ipv4_deladdr(struct ipv4_addr *addr, int keeparp)
 {
 	int r;
 	struct ipv4_state *state;
-	struct ipv4_addr *ap;
+	struct ipv4_addr *ap, *ian;
 
 	logdebugx("%s: deleting IP address %s",
 	    addr->iface->name, addr->saddr);
@@ -506,7 +506,7 @@ ipv4_deladdr(struct ipv4_addr *addr, int keeparp)
 #endif
 
 	state = IPV4_STATE(addr->iface);
-	TAILQ_FOREACH(ap, &state->addrs, next) {
+	TAILQ_FOREACH_SAFE(ap, &state->addrs, next, ian) {
 		if (IPV4_MASK_EQ(ap, addr)) {
 			struct dhcp_state *dstate;
 

--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -597,7 +597,7 @@ void
 ipv6_deleteaddr(struct ipv6_addr *ia)
 {
 	struct ipv6_state *state;
-	struct ipv6_addr *ap;
+	struct ipv6_addr *ap, *ian;
 
 	loginfox("%s: deleting address %s", ia->iface->name, ia->saddr);
 	if (if_address6(RTM_DELADDR, ia) == -1 &&
@@ -608,7 +608,7 @@ ipv6_deleteaddr(struct ipv6_addr *ia)
 	ipv6_deletedaddr(ia);
 
 	state = IPV6_STATE(ia->iface);
-	TAILQ_FOREACH(ap, &state->addrs, next) {
+	TAILQ_FOREACH_SAFE(ap, &state->addrs, next, ian) {
 		if (IN6_ARE_ADDR_EQUAL(&ap->addr, &ia->addr)) {
 			TAILQ_REMOVE(&state->addrs, ap, next);
 			ipv6_freeaddr(ap);


### PR DESCRIPTION
We must use `TAILQ_FOREACH_SAFE` instead of `TAILQ_FOREACH` if we call `TAILQ_REMOVE` on the current item and free it.

Failure to do so can lead to bad behavior such as infinite loops.

A few users of Void Linux are currently experiencing high CPU usage due to this bug in 8.1.1: https://github.com/void-linux/void-packages/pull/15858

https://www.reddit.com/r/voidlinux/comments/donf2w/dhcpcd_consuming_100cpu/

It is difficult to reliably trigger this bug, but when it does occur, a backtrace showed that the process was stuck in `ipv4ll_drop` which calls `ipv4_deladdr`, which in turn had the unsafe traversal where it calls `TAILQ_REMOVE` inside a `TAILQ_FOREACH` rather than `TAILQ_FOREACH_SAFE`.

Further auditing of the code should be performed to ensure the proper loop traversal macro is used to avoid such bugs (I fixed three instances where I believe `TAILQ_FOREACH_SAFE` should be used instead of `TAILQ_FOREACH`, but there may be others).