### PR TITLE
Linux: fix RA time unit confusion

### DIFF
--- a/src/if-linux.c
+++ b/src/if-linux.c
@@ -1948,20 +1948,20 @@ if_applyra(const struct ra *rap)
 		error = -1;
 
 	snprintf(path, sizeof(path), "%s/%s/retrans_time_ms", p_neigh, ifname);
-	if (if_writepathuint(ctx, path, rap->retrans * 1000) == -1) {
+	if (if_writepathuint(ctx, path, rap->retrans) == -1) {
 		snprintf(path, sizeof(path), "%s/%s/retrans_time",
 		    p_neigh, ifname);
 		/* Jiffies */
-		if (if_writepathuint(ctx, path, rap->retrans * 100) == -1)
+		if (if_writepathuint(ctx, path, rap->retrans * sysconf(_SC_CLK_TCK) / 1000) == -1)
 			error = -1;
 	}
 
 	snprintf(path, sizeof(path), "%s/%s/base_reachable_time_ms",
 	    p_neigh, ifname);
-	if (if_writepathuint(ctx, path, rap->reachable * 1000) == -1) {
+	if (if_writepathuint(ctx, path, rap->reachable) == -1) {
 		snprintf(path, sizeof(path), "%s/%s/base_reachable_time",
 		    p_neigh, ifname);
-		if (if_writepathuint(ctx, path, rap->reachable) == -1)
+		if (if_writepathuint(ctx, path, rap->reachable / 1000) == -1)
 			error = -1;
 	}
 	return error;


### PR DESCRIPTION
The RA times are [provided in milliseconds](https://tools.ietf.org/html/rfc4861#section-4.2), but commit 569051c8aa8fc297eb8edb7bd228e0fd353d30c1 (dhcpcd-8.1.3~18) “Linux: prefer ms RA times” incorrectly scaled them by an extra factor of 1000 before writing them to `retrans_time_ms` and `base_reachable_time_ms`. Instead, write the values in milliseconds directly to the `*_ms` files, and correctly convert to jiffies or seconds for the other files if necessary.

Fixes NixOS/nixpkgs#76710.