### PR TITLE
use TEMP_PREFERRED/VALID_LIFETIME for OpenBSD

### DIFF
--- a/src/if-bsd.c
+++ b/src/if-bsd.c
@@ -1730,14 +1730,14 @@ int
 ip6_temp_preferred_lifetime(__unused const char *ifname)
 {
 
-	return ND6_PRIV_PREFERRED_LIFETIME;
+	return TEMP_PREFERRED_LIFETIME;
 }
 
 int
 ip6_temp_valid_lifetime(__unused const char *ifname)
 {
 
-	return ND6_PRIV_VALID_LIFETIME;
+	return TEMP_VALID_LIFETIME;
 }
 
 #else /* __OpenBSD__ */


### PR DESCRIPTION
Shortly after dhcpcd started using these constants, they were dropped from OpenBSD kernel headers as they're only used by rad(8). Switch to dhcpcd's own constants instead, fixing build on recent -current.