### PR TITLE
Do not report an error if control_group is already set

### DIFF
--- a/src/if-options.c
+++ b/src/if-options.c
@@ -2120,7 +2120,8 @@ invalid_token:
 			return -1;
 		}
 		if (grp == NULL) {
-			logerrx("controlgroup: %s: not found", arg);
+			if (!ctx->control_group)
+				logerrx("controlgroup: %s: not found", arg);
 			free(p);
 			return -1;
 		}
@@ -2129,7 +2130,8 @@ invalid_token:
 #else
 		grp = getgrnam(arg);
 		if (grp == NULL) {
-			logerrx("controlgroup: %s: not found", arg);
+			if (!ctx->control_group)
+				logerrx("controlgroup: %s: not found", arg);
 			return -1;
 		}
 		ctx->control_group = grp->gr_gid;


### PR DESCRIPTION
After an update I noticed that dhcpcd reported an error "controlgroup: wheel: not found". Looking into the code it seems that this is due to the new privsep code not moving /etc/group in the chroot. This patch is a quick fix for the error that simply checks if control_group was already parsed successfully.

Here is what the error looked like on my machine:
```
[root@light ~]# dhcpcd wlp3s0
dhcpcd-9.0.2 starting
controlgroup: wheel: not found
wlp3s0: connected to Access Point `Maison'
...
```
