### PR TITLE
Fix neighbor discovery option parsing

### DIFF
--- a/src/dhcp-common.c
+++ b/src/dhcp-common.c
@@ -202,8 +202,8 @@ make_option_mask(const struct dhcp_opt *dopts, size_t dopts_len,
 			continue;
 		if (strncmp(token, "dhcp6_", 6) == 0)
 			token += 6;
-		if (strncmp(token, "nd6_", 4) == 0)
-			token += 4;
+		if (strncmp(token, "nd_", 3) == 0)
+			token += 3;
 		match = 0;
 		for (i = 0, opt = odopts; i < odopts_len; i++, opt++) {
 			if (opt->var == NULL || opt->option == 0)

--- a/src/dhcpcd.conf.5.in
+++ b/src/dhcpcd.conf.5.in
@@ -792,7 +792,7 @@ with a name of
 exported to
 .Xr dhcpcd-run-hooks 8 ,
 with a prefix of
-.Va _nd .
+.Va nd_ .
 .It Ic define6 Ar code Ar type Ar variable
 Defines the DHCPv6 option
 .Ar code
@@ -803,7 +803,7 @@ with a name of
 exported to
 .Xr dhcpcd-run-hooks 8 ,
 with a prefix of
-.Va _dhcp6 .
+.Va dhcp6_ .
 .It Ic vendopt Ar code Ar type Ar variable
 Defines the Vendor-Identifying Vendor Options.
 The


### PR DESCRIPTION
Resolves
```
$ dhcpcd --nooption nd_prefix_information
unknown option `nd_prefix_information'
```

See commit message for details