### PR TITLE
Script execution debug log: Replace back-tick by single quote

### DIFF
--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -1164,7 +1164,7 @@ read_lease(struct interface *ifp, struct bootp **bootp)
 		logdebugx("reading standard input");
 		sbytes = read(fileno(stdin), buf.buf, sizeof(buf.buf));
 	} else {
-		logdebugx("%s: reading lease `%s'",
+		logdebugx("%s: reading lease '%s'",
 		    ifp->name, state->leasefile);
 		sbytes = dhcp_readfile(ifp->ctx, state->leasefile,
 		    buf.buf, sizeof(buf.buf));
@@ -2314,7 +2314,7 @@ dhcp_bind(struct interface *ifp)
 	state->state = DHS_BOUND;
 	if (!state->lease.frominfo &&
 	    !(ifo->options & (DHCPCD_INFORM | DHCPCD_STATIC))) {
-		logdebugx("%s: writing lease `%s'",
+		logdebugx("%s: writing lease '%s'",
 		    ifp->name, state->leasefile);
 		if (dhcp_writefile(ifp->ctx, state->leasefile, 0640,
 		    state->new, state->new_len) == -1)
@@ -2865,10 +2865,10 @@ log_dhcp(int loglevel, const char *msg,
 		print_string(sname, sizeof(sname), OT_STRING | OT_DOMAIN,
 		    bootp->sname, sizeof(bootp->sname));
 		if (a == NULL)
-			logmessage(loglevel, "%s: %s %s %s `%s'",
+			logmessage(loglevel, "%s: %s %s %s '%s'",
 			    ifp->name, msg, tfrom, inet_ntoa(addr), sname);
 		else
-			logmessage(loglevel, "%s: %s %s %s %s `%s'",
+			logmessage(loglevel, "%s: %s %s %s %s '%s'",
 			    ifp->name, msg, a, tfrom, inet_ntoa(addr), sname);
 	} else {
 		if (r != 0) {

--- a/src/dhcp6.c
+++ b/src/dhcp6.c
@@ -2588,7 +2588,7 @@ dhcp6_readlease(struct interface *ifp, int validate)
 		logdebugx("reading standard input");
 		bytes = read(fileno(stdin), buf.buf, sizeof(buf.buf));
 	} else {
-		logdebugx("%s: reading lease `%s'",
+		logdebugx("%s: reading lease '%s'",
 		    ifp->name, state->leasefile);
 		bytes = dhcp_readfile(ifp->ctx, state->leasefile,
 		    buf.buf, sizeof(buf.buf));
@@ -3218,7 +3218,7 @@ dhcp6_bind(struct interface *ifp, const char *op, const char *sfrom)
 			    ifp->name, state->expire);
 		rt_build(ifp->ctx, AF_INET6);
 		if (!confirmed && !timedout) {
-			logdebugx("%s: writing lease `%s'",
+			logdebugx("%s: writing lease '%s'",
 			    ifp->name, state->leasefile);
 			if (dhcp_writefile(ifp->ctx, state->leasefile, 0640,
 			    state->new, state->new_len) == -1)
@@ -3657,12 +3657,12 @@ dhcp6_recvmsg(struct dhcpcd_ctx *ctx, struct msghdr *msg, struct ipv6_addr *ia)
 	    "/tmp/dhcp6.reply%d.raw", replyn++);
 	fd = open(fname, O_RDONLY, 0);
 	if (fd == -1) {
-		logerr("%s: open `%s'", __func__, fname);
+		logerr("%s: open '%s'", __func__, fname);
 		return;
 	}
 	tlen = read(fd, tbuf, sizeof(tbuf));
 	if (tlen == -1)
-		logerr("%s: read `%s'", __func__, fname);
+		logerr("%s: read '%s'", __func__, fname);
 	close(fd);
 
 	/* Copy across ServerID so we can work with our own server. */

--- a/src/dhcpcd.c
+++ b/src/dhcpcd.c
@@ -700,7 +700,7 @@ dhcpcd_reportssid(struct interface *ifp)
 		return;
 	}
 
-	loginfox("%s: connected to Access Point `%s'", ifp->name, pssid);
+	loginfox("%s: connected to Access Point '%s'", ifp->name, pssid);
 }
 
 void
@@ -2080,7 +2080,7 @@ printpidfile:
 	}
 
 	if (chdir("/") == -1)
-		logerr("%s: chdir `/'", __func__);
+		logerr("%s: chdir '/'", __func__);
 
 	/* Freeing allocated addresses from dumping leases can trigger
 	 * eloop removals as well, so init here. */
@@ -2240,9 +2240,9 @@ printpidfile:
 	if (!(ctx.options & DHCPCD_TEST)) {
 		/* Ensure we have the needed directories */
 		if (mkdir(DBDIR, 0750) == -1 && errno != EEXIST)
-			logerr("%s: mkdir `%s'", __func__, DBDIR);
+			logerr("%s: mkdir '%s'", __func__, DBDIR);
 		if (mkdir(RUNDIR, 0755) == -1 && errno != EEXIST)
-			logerr("%s: mkdir `%s'", __func__, RUNDIR);
+			logerr("%s: mkdir '%s'", __func__, RUNDIR);
 		if ((pid = pidfile_lock(ctx.pidfile)) != 0) {
 			if (pid == -1)
 				logerr("%s: pidfile_lock: %s",

--- a/src/if-options.c
+++ b/src/if-options.c
@@ -460,13 +460,13 @@ parse_addr(struct in_addr *addr, struct in_addr *net, const char *arg)
 		if (e != 0 ||
 		    (net != NULL && inet_cidrtoaddr((int)i, net) != 0))
 		{
-			logerrx("`%s' is not a valid CIDR", p);
+			logerrx("'%s' is not a valid CIDR", p);
 			return -1;
 		}
 	}
 
 	if (addr != NULL && inet_aton(arg, addr) == 0) {
-		logerrx("`%s' is not a valid IP address", arg);
+		logerrx("'%s' is not a valid IP address", arg);
 		return -1;
 	}
 	if (p != NULL)
@@ -788,7 +788,7 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 		    make_option_mask(d, dl, od, odl, no, arg, -1) != 0 ||
 		    make_option_mask(d, dl, od, odl, reject, arg, -1) != 0)
 		{
-			logerrx("unknown option `%s'", arg);
+			logerrx("unknown option '%s'", arg);
 			return -1;
 		}
 		break;
@@ -800,7 +800,7 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 		    make_option_mask(d, dl, od, odl, request, arg, -1) != 0 ||
 		    make_option_mask(d, dl, od, odl, require, arg, -1) != 0)
 		{
-			logerrx("unknown option `%s'", arg);
+			logerrx("unknown option '%s'", arg);
 			return -1;
 		}
 		break;
@@ -1003,7 +1003,7 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 		else if (strcmp(arg, "disable") == 0)
 			ifo->fqdn = FQDN_DISABLE;
 		else {
-			logerrx("invalid value `%s' for FQDN", arg);
+			logerrx("invalid value '%s' for FQDN", arg);
 			return -1;
 		}
 		break;
@@ -1049,7 +1049,7 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 		    make_option_mask(d, dl, od, odl, require, arg, -1) != 0 ||
 		    make_option_mask(d, dl, od, odl, no, arg, 1) != 0)
 		{
-			logerrx("unknown option `%s'", arg);
+			logerrx("unknown option '%s'", arg);
 			return -1;
 		}
 		break;
@@ -1062,7 +1062,7 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 		    make_option_mask(d, dl, od, odl, no, arg, -1) != 0 ||
 		    make_option_mask(d, dl, od, odl, reject, arg, -1) != 0)
 		{
-			logerrx("unknown option `%s'", arg);
+			logerrx("unknown option '%s'", arg);
 			return -1;
 		}
 		break;
@@ -1299,10 +1299,10 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 		    ifo->dstmask, arg, 2) != 0)
 		{
 			if (errno == EINVAL)
-				logerrx("option `%s' does not take"
+				logerrx("option '%s' does not take"
 				    " an IPv4 address", arg);
 			else
-				logerrx("unknown option `%s'", arg);
+				logerrx("unknown option '%s'", arg);
 			return -1;
 		}
 		break;
@@ -1785,7 +1785,7 @@ err_sla:
 			return -1;
 		}
 		if (l && !(t & (OT_STRING | OT_BINHEX))) {
-			logwarnx("ignoring length for type `%s'", arg);
+			logwarnx("ignoring length for type '%s'", arg);
 			l = 0;
 		}
 		if (t & OT_ARRAY && t & (OT_STRING | OT_BINHEX) &&

--- a/src/privsep.c
+++ b/src/privsep.c
@@ -118,11 +118,11 @@ ps_dropprivs(struct dhcpcd_ctx *ctx)
 	struct passwd *pw = ctx->ps_user;
 
 	if (!(ctx->options & DHCPCD_FORKED))
-		logdebugx("chrooting to `%s' as %s", pw->pw_dir, pw->pw_name);
+		logdebugx("chrooting to '%s' as %s", pw->pw_dir, pw->pw_name);
 	if (chroot(pw->pw_dir) == -1)
-		logerr("%s: chroot `%s'", __func__, pw->pw_dir);
+		logerr("%s: chroot '%s'", __func__, pw->pw_dir);
 	if (chdir("/") == -1)
-		logerr("%s: chdir `/'", __func__);
+		logerr("%s: chdir '/'", __func__);
 
 	if ((setgroups(1, &pw->pw_gid) == -1 ||
 	     setgid(pw->pw_gid) == -1 ||

--- a/src/script.c
+++ b/src/script.c
@@ -736,7 +736,7 @@ script_runreason(const struct interface *ifp, const char *reason)
 
 	argv[0] = ctx->script;
 	argv[1] = NULL;
-	logdebugx("%s: executing `%s' %s", ifp->name, argv[0], reason);
+	logdebugx("%s: executing '%s' %s", ifp->name, argv[0], reason);
 
 #ifdef PRIVSEP
 	if (ctx->options & DHCPCD_PRIVSEP) {


### PR DESCRIPTION
This PR replaces the initial back-tick before the script name by a single quote. Simplifies parsing of the output log

Before:
```
dhcpcd-9.1.4 starting
no such user dhcpcd
DUID 00:04:72:01:1e:01:52:c2:11:cb:9d:49:d3:65:99:10:ec:5c
dummy0: executing `/usr/libexec/dhcpcd-run-hooks' PREINIT
dummy0: executing `/usr/libexec/dhcpcd-run-hooks' CARRIER
dummy0: IAID 26:55:d3:72
dummy0: delaying IPv4 for 0.7 seconds
dummy0: reading lease `/var/db/dhcpcd/dummy0.lease'
dummy0: soliciting a DHCP lease
dummy0: sending DISCOVER (xid 0xc74ba8ba), next in 3.1 seconds
[...]
```

After:
```
dhcpcd-9.1.4 starting
no such user dhcpcd
DUID 00:04:72:01:1e:01:52:c2:11:cb:9d:49:d3:65:99:10:ec:5c
dummy0: executing '/usr/libexec/dhcpcd-run-hooks' PREINIT
dummy0: executing '/usr/libexec/dhcpcd-run-hooks' CARRIER
dummy0: IAID 26:55:d3:72
dummy0: delaying IPv4 for 0.7 seconds
dummy0: reading lease '/var/db/dhcpcd/dummy0.lease'
dummy0: soliciting a DHCP lease
dummy0: sending DISCOVER (xid 0xc74ba8ba), next in 3.1 seconds
[...]
```

(Compare lines 4, 5 & 8)