### PR TITLE
src/dhcpcd.c: fix build without fork or signals

### DIFF
--- a/src/dhcpcd.c
+++ b/src/dhcpcd.c
@@ -2310,10 +2310,10 @@ printpidfile:
 	if (ctx.stdin_valid && freopen(_PATH_DEVNULL, "w", stdin) == NULL)
 		logwarn("freopen stdin");
 
+#if defined(USE_SIGNALS) && !defined(THERE_IS_NO_FORK)
 	if (!(ctx.options & DHCPCD_DAEMONISE))
 		goto start_master;
 
-#if defined(USE_SIGNALS) && !defined(THERE_IS_NO_FORK)
 	if (xsocketpair(AF_UNIX, SOCK_DGRAM | SOCK_CXNB, 0, fork_fd) == -1 ||
 	    (ctx.stderr_valid &&
 	    xsocketpair(AF_UNIX, SOCK_DGRAM | SOCK_CXNB, 0, stderr_fd) == -1))


### PR DESCRIPTION
Since version 9.3.3 and commit a5348dd02c86fa940cd93f203d0aa974cae0563c, build without fork or signals fails on:

```
dhcpcd.c: In function ‘main’:
dhcpcd.c:2261:3: error: label ‘start_master’ used but not defined
   goto start_master;
   ^~~~
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>