### PR TITLE
src/privsep-linux.c: add support for nds32

### DIFF
--- a/src/privsep-linux.c
+++ b/src/privsep-linux.c
@@ -182,6 +182,8 @@ ps_root_sendnetlink(struct dhcpcd_ctx *ctx, int protocol, struct msghdr *msg)
 #  else
 #    define SECCOMP_AUDIT_ARCH AUDIT_ARCH_MIPS
 #  endif
+#elif defined(__nds32__)
+#  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_NDS32
 #elif defined(__powerpc64__)
 #  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_PPC64
 #elif defined(__powerpc__)


### PR DESCRIPTION
Fix the following build failure:

```
privsep-linux.c:206:4: error: #error "Platform does not support seccomp filter yet"
 #  error "Platform does not support seccomp filter yet"
    ^~~~~
In file included from privsep-linux.c:36:
privsep-linux.c:213:38: error: 'SECCOMP_AUDIT_ARCH' undeclared here (not in a function); did you mean 'SECCOMP_ALLOW_ARG'?
  BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, SECCOMP_AUDIT_ARCH, 1, 0),
                                      ^~~~~~~~~~~~~~~~~~
```

It should be noted that `AUDIT_ARCH_NDS32` is only defined since kernel 5.2 and https://github.com/torvalds/linux/commit/fa562447e154334523daa44c0b60625d71a345f5

Fixes:
 - http://autobuild.buildroot.org/results/af8ba07ea0c12ab8cd24d528ef98db05521f3d36

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>