### PR TITLE
 src/privsep-linux.c: add support for xtensa

### DIFF
--- a/src/privsep-linux.c
+++ b/src/privsep-linux.c
@@ -204,6 +204,8 @@ ps_root_sendnetlink(struct dhcpcd_ctx *ctx, int protocol, struct msghdr *msg)
 #  else
 #    define AUDIT_ARCH_SPARC
 #  endif
+#elif defined(__xtensa__)
+#  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_XTENSA
 #else
 #  error "Platform does not support seccomp filter yet"
 #endif


### PR DESCRIPTION
Fix the following build failure:

```
privsep-linux.c:206:4: error: #error "Platform does not support seccomp filter yet"
 #  error "Platform does not support seccomp filter yet"
    ^~~~~
In file included from privsep-linux.c:36:
privsep-linux.c:213:38: error: 'SECCOMP_AUDIT_ARCH' undeclared here (not in a function); did you mean 'SECCOMP_ALLOW_ARG'?
  BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, SECCOMP_AUDIT_ARCH, 1, 0),
                                      ^~~~~~~~~~~~~~~~~~
```

It should be noted that `AUDIT_ARCH_XTENSA` is only defined since kernel 5.0 and https://github.com/torvalds/linux/commit/98c3115a4ec56f03056efd9295e0fcb4c5c57a85

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>