### PR TITLE
src/privsep-linux.c: add support for or1k

### DIFF
--- a/src/privsep-linux.c
+++ b/src/privsep-linux.c
@@ -192,6 +192,8 @@ ps_root_sendnetlink(struct dhcpcd_ctx *ctx, int protocol, struct msghdr *msg)
 #endif
 #elif defined(__nios2__)
 #  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_NIOS2
+#elif defined(__or1k__)
+#  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_OPENRISC
 #elif defined(__powerpc64__)
 #  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_PPC64
 #elif defined(__powerpc__)


### PR DESCRIPTION
Fix the following build failure:

```
privsep-linux.c:206:4: error: #error "Platform does not support seccomp filter yet"
 #  error "Platform does not support seccomp filter yet"
    ^~~~~
In file included from privsep-linux.c:36:
privsep-linux.c:213:38: error: 'SECCOMP_AUDIT_ARCH' undeclared here (not in a function); did you mean 'SECCOMP_ALLOW_ARG'?
  BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, SECCOMP_AUDIT_ARCH, 1, 0),
                                      ^~~~~~~~~~~~~~~~~~
```

It should be noted that AUDIT_ARCH_OPENRISC is defined since kernel 3.7: https://github.com/torvalds/linux/commit/e2bebb4ae6d9ac4ffc524db67f7ecb205a173f77

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>