### PR TITLE
src/privsep-linux.c: add support for arc

### DIFF
--- a/src/privsep-linux.c
+++ b/src/privsep-linux.c
@@ -149,6 +149,22 @@ ps_root_sendnetlink(struct dhcpcd_ctx *ctx, int protocol, struct msghdr *msg)
 #  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_I386
 #elif defined(__x86_64__)
 #  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_X86_64
+#elif defined(__arc__)
+#  if defined(__A7__)
+#    if (BYTE_ORDER == LITTLE_ENDIAN)
+#      define SECCOMP_AUDIT_ARCH AUDIT_ARCH_ARCOMPACT
+#    else
+#      define SECCOMP_AUDIT_ARCH AUDIT_ARCH_ARCOMPACTBE
+#    endif
+#  elif defined(__HS__)
+#    if (BYTE_ORDER == LITTLE_ENDIAN)
+#      define SECCOMP_AUDIT_ARCH AUDIT_ARCH_ARCV2
+#    else
+#      define SECCOMP_AUDIT_ARCH AUDIT_ARCH_ARCV2BE
+#    endif
+#  else
+#    error "Platform does not support seccomp filter yet"
+#  endif
 #elif defined(__arm__)
 #  ifndef EM_ARM
 #    define EM_ARM 40


### PR DESCRIPTION
Fix the following build failure:

```
privsep-linux.c:206:4: error: #error "Platform does not support seccomp filter yet"
 #  error "Platform does not support seccomp filter yet"
    ^~~~~
In file included from privsep-linux.c:36:
privsep-linux.c:213:38: error: 'SECCOMP_AUDIT_ARCH' undeclared here (not in a function); did you mean 'SECCOMP_ALLOW_ARG'?
  BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, SECCOMP_AUDIT_ARCH, 1, 0),
                                      ^~~~~~~~~~~~~~~~~~
```

It should be noted that `AUDIT_ARCH_{ARCOMPACT,ARCV2}` is only defined since kernel 5.2 and https://github.com/torvalds/linux/commit/67f2a8a29311841ba6ab9b0e2d1b8f1e9978cd84

Detection of arc compact and arc v2 have been "copy/pasted" from https://github.com/wbx-github/uclibc-ng/commit/afab56958f1cbb47b831ee3ebff231dfbae74af2

Fixes:
 - http://autobuild.buildroot.org/results/d29083700a80dd647621eed06faeeae03f0587d3

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>