### PR TITLE
src/privsep-linux.c: add support for m68k

### DIFF
--- a/src/privsep-linux.c
+++ b/src/privsep-linux.c
@@ -188,6 +188,8 @@ ps_root_sendnetlink(struct dhcpcd_ctx *ctx, int protocol, struct msghdr *msg)
 #  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_IA64
 #elif defined(__microblaze__)
 #  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_MICROBLAZE
+#elif defined(__m68k__)
+#  define SECCOMP_AUDIT_ARCH AUDIT_ARCH_M68K
 #elif defined(__mips__)
 #  if defined(__MIPSEL__)
 #    if defined(__LP64__)


### PR DESCRIPTION
Fix the following build failure:

```
privsep-linux.c:206:4: error: #error "Platform does not support seccomp filter yet"
 #  error "Platform does not support seccomp filter yet"
    ^~~~~
In file included from privsep-linux.c:36:
privsep-linux.c:213:38: error: 'SECCOMP_AUDIT_ARCH' undeclared here (not in a function); did you mean 'SECCOMP_ALLOW_ARG'?
  BPF_JUMP(BPF_JMP + BPF_JEQ + BPF_K, SECCOMP_AUDIT_ARCH, 1, 0),
                                      ^~~~~~~~~~~~~~~~~~
```

Signed-off-by: Fabrice Fontaine <fontaine.fabrice@gmail.com>