### PR TITLE
[WIP] Linux: set broadcast flag by default for ipvlan interfaces.

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -63,6 +63,10 @@
 #define ROUNDUP4(a)		(1 + (((a) - 1) |  3))
 #define ROUNDUP8(a)		(1 + (((a) - 1) |  7))
 
+#ifndef FIELD_SIZEOF
+#define FIELD_SIZEOF(t, f) sizeof(((t *)0)->f)
+#endif
+
 /* Some systems don't define timespec macros */
 #ifndef timespecclear
 #define timespecclear(tsp)      (tsp)->tv_sec = (time_t)((tsp)->tv_nsec = 0L)

--- a/src/dhcpcd.8.in
+++ b/src/dhcpcd.8.in
@@ -651,7 +651,7 @@ of a randomly generated number.
 .It Fl J , Fl Fl broadcast
 Instructs the DHCP server to broadcast replies back to the client.
 Normally this is only set for non-Ethernet interfaces,
-such as FireWire and InfiniBand.
+such as FireWire and InfiniBand, and on Linux-based systems for ipvlan as well.
 In most instances,
 .Nm
 will set this automatically.

--- a/src/dhcpcd.c
+++ b/src/dhcpcd.c
@@ -470,7 +470,7 @@ configure_interface1(struct interface *ifp)
 
 	if (!(ifo->options & DHCPCD_IAID)) {
 		/*
-		 * An IAID is for identifying a unqiue interface within
+		 * An IAID is for identifying an unique interface within
 		 * the client. It is 4 bytes long. Working out a default
 		 * value is problematic.
 		 *

--- a/src/if-linux.c
+++ b/src/if-linux.c
@@ -338,10 +338,9 @@ if_cmp_driver(struct interface *ifp, const char *driver)
 		logerr("%s: if_get_driver ifname=%s", __func__, ifp->name);
 	} else if (n == 0) {
 		logerr("%s: driver name empty ifname=%s", __func__, ifp->name);
-	} else if (n > 0) {
-		if (strncmp(ifdriver, driver, n) == 0)
-			return true;
 	}
+	if ((n >= 0) && (strncmp(ifdriver, driver, (size_t)n) == 0))
+		return true;
 	return false;
 }
 


### PR DESCRIPTION
The patch uses ethtool's `SIOCETHTOOL` `ioctl` to obtain the driver name of the interface, and turns on the broadcast flag by default when it detects an `ipvlan` interface.  This does not yet differentiate between L2, L3, or L3S mode.

@rsmarples we can use this `ethtool` method to detect most other device types, like `bridge` and `tuntap`, without reading `/sys`.  I might refactor those after this is cleaned up.

TODO:
- [ ] Modify DHCP IAID so that `ipvlan` interfaces do not generate an IAID conflict: `ipvlan0: IAID conflicts with one assigned to eth0`
- [x] Clean up patch before merging.

Fixes #32 