### PR TITLE
dhcpcd-9.4.0: Fix infinite DHCP INFORM messages

### DIFF
--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -2619,6 +2619,7 @@ dhcp_inform(struct interface *ifp)
 	    &ia->addr, &ia->mask);
 	if (state->offer_len) {
 		dhcp_new_xid(ifp);
+		get_lease(ifp, &state->lease, state->offer, state->offer_len);
 		send_inform(ifp);
 	}
 }


### PR DESCRIPTION
When an address is configured on the interface, do not send a DHCP
INFORM message if the interface is already bound (ack already received)

The second issue is that dhcp_inform resets the lease information, and
may drop the existing server address.

#47 