### PR TITLE
Don't configure an IPv6 link-local address if noipv6rs is set

### DIFF
--- a/src/if-linux.c
+++ b/src/if-linux.c
@@ -2173,6 +2173,11 @@ if_setup_inet6(const struct interface *ifp)
 	int ra;
 	char path[256];
 
+	/* If not doing autoconf, don't disable the kernel from doing it.
+	 * If we need to, we should have another option actively disable it. */
+	if (!(ifp->options->options & DHCPCD_IPV6RS))
+		return;
+
 	/* Modern linux kernels can make a stable private address.
 	 * However, a lot of distros ship newer kernel headers than
 	 * the kernel itself so we sweep that error under the table
@@ -2180,11 +2185,6 @@ if_setup_inet6(const struct interface *ifp)
 	if (if_disable_autolinklocal(ctx, ifp->index) == -1 &&
 	    errno != ENODEV && errno != ENOTSUP && errno != EINVAL)
 		logdebug("%s: if_disable_autolinklocal", ifp->name);
-
-	/* If not doing autoconf, don't disable the kernel from doing it.
-	 * If we need to, we should have another option actively disable it. */
-	if (!(ifp->options->options & DHCPCD_IPV6RS))
-		return;
 
 	snprintf(path, sizeof(path), "%s/%s/autoconf", p_conf, ifp->name);
 	ra = check_proc_int(ctx, path);

--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -1428,7 +1428,8 @@ ipv6_addlinklocal(struct interface *ifp)
 	struct ipv6_addr *ap, *ap2;
 	int dadcounter;
 
-	if (!(ifp->options->options & DHCPCD_CONFIGURE))
+	if (!(ifp->options->options & DHCPCD_CONFIGURE) ||
+	    !(ifp->options->options & DHCPCD_IPV6RS))
 		return 0;
 
 	/* Check sanity before malloc */


### PR DESCRIPTION
The configuration I'm using uses the noipv6rs option to allow the Linux kernel to do router discovery, slaac, etc. I'm seeing dhcpcd configuring an EUI64 format link-local address unnecessarily. This change stops dhcpcd from doing that.