### PR TITLE
FreeBSD: Introduce `vlan_pcp` option for VLAN PCP tagging

### DIFF
--- a/src/bpf.c
+++ b/src/bpf.c
@@ -162,6 +162,9 @@ bpf_open(const struct interface *ifp,
 #ifdef BIOCIMMEDIATE
 	unsigned int flags;
 #endif
+#ifdef BIOCSETVLANPCP
+	unsigned int vlan_pcp;
+#endif
 #ifndef O_CLOEXEC
 	int fd_opts;
 #endif
@@ -206,6 +209,14 @@ bpf_open(const struct interface *ifp,
 	strlcpy(ifr.ifr_name, ifp->name, sizeof(ifr.ifr_name));
 	if (ioctl(bpf->bpf_fd, BIOCSETIF, &ifr) == -1)
 		goto eexit;
+
+#ifdef BIOCSETVLANPCP
+	if (ifp->options->vlan_pcp != -1) {
+		vlan_pcp = (u_int)ifp->options->vlan_pcp;
+		if (ioctl(bpf->bpf_fd, BIOCSETVLANPCP, &vlan_pcp) == -1)
+			goto eexit;
+	}
+#endif
 
 #ifdef BIOCIMMEDIATE
 	flags = 1;

--- a/src/if-options.h
+++ b/src/if-options.h
@@ -33,6 +33,7 @@
 #include <sys/socket.h>
 #include <net/if.h>
 #include <netinet/in.h>
+#include <net/bpf.h>
 
 #include <getopt.h>
 #include <limits.h>
@@ -190,6 +191,9 @@
 #define O_VSIO			O_BASE + 57
 #define O_VSIO6			O_BASE + 58
 #define O_NOSYSLOG		O_BASE + 59
+#ifdef BIOCSETVLANPCP
+#define O_VLANPCP		O_BASE + 60
+#endif
 
 extern const struct option cf_options[];
 
@@ -313,6 +317,10 @@ struct if_options {
 #endif
 
 	struct auth auth;
+
+#ifdef BIOCSETVLANPCP
+	int vlan_pcp;
+#endif
 };
 
 struct if_options *read_config(struct dhcpcd_ctx *,

--- a/src/if.h
+++ b/src/if.h
@@ -73,6 +73,8 @@ typedef unsigned long		ioctl_request_t;
 #include "ipv6.h"
 #include "route.h"
 
+#define VLAN_PCP_MAX			7
+
 #define EUI64_ADDR_LEN			8
 #define INFINIBAND_ADDR_LEN		20
 


### PR DESCRIPTION
This is needed to achieve feature parity with dhclient(8) in FreeBSD.

https://reviews.freebsd.org/D31263

```
This allows the use of VLAN PCP in dhclient, which is required for
certain ISPs (such as Orange.fr).
```

Still needs documentation.