### PR TITLE
privsep: Ensure we recv for real after a successful recv MSG_PEEK

### DIFF
--- a/src/privsep-root.c
+++ b/src/privsep-root.c
@@ -131,14 +131,19 @@ ps_root_readerrorcb(struct psr_ctx *psr_ctx)
 			/* psr_mdatalen could be smaller then psr_datalen
 			 * if the above malloc failed. */
 			iov[1].iov_len =
-			    MIN(psr_ctx->psr_mdatalen, psr_ctx->psr_datalen);
+			    MIN(psr_ctx->psr_mdatalen, psr_error->psr_datalen);
 		} else {
 			iov[1].iov_base = psr_ctx->psr_data;
-			iov[1].iov_len = psr_ctx->psr_datalen;
+			/* This should never be the case */
+			iov[1].iov_len =
+			    MIN(psr_ctx->psr_datalen, psr_error->psr_datalen);
 		}
 	}
 
 recv:
+	/* fd is SOCK_SEQPACKET and we mark the boundary with MSG_EOR
+	 * so this can never stall if the receive buffers are bigger
+	 * than the actual message. */
 	len = recvmsg(fd, &msg, MSG_WAITALL);
 	if (len == -1)
 		PSR_ERROR(errno);

--- a/src/privsep-root.c
+++ b/src/privsep-root.c
@@ -115,7 +115,7 @@ ps_root_readerrorcb(struct psr_ctx *psr_ctx)
 	{
 		void *d = realloc(psr_ctx->psr_mdata, psr_error->psr_datalen);
 
-		/* If we failed to malloc then psr_mdatalen will be smaller
+		/* If we failed to realloc then psr_mdatalen will be smaller
 		 * than psr_datalen.
 		 * The following recvmsg will get MSG_TRUNC so the malloc error
 		 * will be reported there but more importantly the
@@ -140,9 +140,6 @@ ps_root_readerrorcb(struct psr_ctx *psr_ctx)
 	}
 
 recv:
-	/* fd is SOCK_SEQPACKET and we mark the boundary with MSG_EOR
-	 * so this can never stall if the receive buffers are bigger
-	 * than the actual message. */
 	len = recvmsg(fd, &msg, MSG_WAITALL);
 	if (len == -1)
 		PSR_ERROR(errno);

--- a/src/privsep-root.c
+++ b/src/privsep-root.c
@@ -89,9 +89,8 @@ ps_root_readerrorcb(struct psr_ctx *pc)
 
 #define PSR_ERROR(e)				\
 	do {					\
-		psr_error->psr_result = -1;	\
 		psr_error->psr_errno = (e);	\
-		return -1;			\
+		goto error;			\
 	} while (0 /* CONSTCOND */)
 
 	if (eloop_waitfd(fd) == -1)
@@ -143,6 +142,14 @@ recv:
 		PSR_ERROR(EBADMSG);
 	}
 	return len;
+
+error:
+	psr_error->psr_result = -1;
+	if (pc->psr_mallocdata && pc->psr_data != NULL) {
+		free(pc->psr_data);
+		pc->psr_data = NULL;
+	}
+	return -1;
 }
 
 ssize_t

--- a/src/privsep-root.c
+++ b/src/privsep-root.c
@@ -136,8 +136,10 @@ recv:
 	else if (msg.msg_flags & MSG_TRUNC)
 		PSR_ERROR(ENOBUFS);
 	else if ((size_t)len != sizeof(*psr_error) + psr_error->psr_datalen) {
+#ifdef PRIVSEP_DEBUG
 		logerrx("%s: recvmsg returned %zd, expecting %zu", __func__,
 		    len, sizeof(*psr_error) + psr_error->psr_datalen);
+#endif
 		PSR_ERROR(EBADMSG);
 	}
 	return len;

--- a/src/privsep.c
+++ b/src/privsep.c
@@ -761,11 +761,6 @@ ps_freeprocess(struct ps_process *psp)
 
 	TAILQ_REMOVE(&ctx->ps_processes, psp, next);
 
-	if (psp->psp_freedata != NULL)
-		psp->psp_freedata(psp->psp_data);
-	else
-		free(psp->psp_data);
-
 	if (psp->psp_fd != -1) {
 		eloop_event_delete(ctx->eloop, psp->psp_fd);
 		close(psp->psp_fd);

--- a/src/privsep.h
+++ b/src/privsep.h
@@ -184,8 +184,6 @@ struct ps_process {
 	char psp_name[PSP_NAMESIZE];
 	uint16_t psp_proto;
 	const char *psp_protostr;
-	void *psp_data;
-	void (*psp_freedata)(void *);
 	bool psp_started;
 
 #ifdef INET


### PR DESCRIPTION
Adjust the code flow so that the same errors would be caught after the final recv.
This ensures we read what is really meant for us and not something silly.

Should fix #555.