### PR TITLE
options: Ensure ldop is not NULL dereferenced

### DIFF
--- a/src/if-options.c
+++ b/src/if-options.c
@@ -1882,7 +1882,7 @@ err_sla:
 			if (*edop) {
 				dop = &(*edop)->embopts;
 				dop_len = &(*edop)->embopts_len;
-			} else if (ldop) {
+			} else if (*ldop) {
 				dop = &(*ldop)->embopts;
 				dop_len = &(*ldop)->embopts_len;
 			} else {


### PR DESCRIPTION
ldop itself cannot be non NULL as it points to the location. but *ldop CAN be NULL.

Fixes #567.