### PR TITLE
common: Cast via uintptr_t rather than unsigned long in UNCONST

### DIFF
--- a/src/common.h
+++ b/src/common.h
@@ -55,7 +55,7 @@
 #define MAX(a,b)		((/*CONSTCOND*/(a)>(b))?(a):(b))
 #endif
 
-#define UNCONST(a)		((void *)(unsigned long)(const void *)(a))
+#define UNCONST(a)		((void *)(uintptr_t)(const void *)(a))
 #define STRINGIFY(a)		#a
 #define TOSTRING(a)		STRINGIFY(a)
 #define UNUSED(a)		(void)(a)


### PR DESCRIPTION
On ILP32 and LP64 systems, unsigned long is sufficient to round-trip pointers, but on LLP64 systems it is too small, and on systems like CHERI where pointers are capabilities, it does not propagate capability metadata, and casting back to a pointer to yield a pointer that cannot be dereferenced.

Instead, cast via uintptr_t to ensure we always use an integral type that can losslessly round-trip pointers.