### PR TITLE
DHCP: Don't run double EXPIRE hooks on carrier loss

### DIFF
--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -2896,8 +2896,8 @@ dhcp_deconfigure(void *arg)
 	else {
 		state->addr = NULL;
 		state->added = 0;
+		script_runreason(ifp, reason);
 	}
-	script_runreason(ifp, reason);
 	free(state->old);
 	state->old = NULL;
 	state->old_len = 0;


### PR DESCRIPTION
Fixes #587.