### PR TITLE
Add missing SPDX-License tags

### DIFF
--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,3 +1,6 @@
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
+<!-- Copyright (c) 2017-2025 Roy Marples <roy@marples.name> -->
+
 # Building dhcpcd
 
 This attempts to document various ways of building dhcpcd for your

--- a/BUILDING.md
+++ b/BUILDING.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: BSD-3-Clause -->
+<!-- SPDX-License-Identifier: BSD-2-Clause -->
 <!-- Copyright (c) 2017-2025 Roy Marples <roy@marples.name> -->
 
 # Building dhcpcd

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
+
 SUBDIRS=	src hooks
 
 PACKAGE=	dhcpcd

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
 
 SUBDIRS=	src hooks

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2009-2025 Roy Marples <roy@marples.name>
+
 # System definitions
 
 PICFLAG?=	-fPIC

--- a/Makefile.inc
+++ b/Makefile.inc
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2009-2025 Roy Marples <roy@marples.name>
 
 # System definitions

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: BSD-3-Clause -->
+<!-- SPDX-License-Identifier: BSD-2-Clause -->
 <!-- Copyright (c) 2017-2023 Roy Marples <roy@marples.name> -->
 
 # dhcpcd

--- a/README.md
+++ b/README.md
@@ -1,3 +1,6 @@
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
+<!-- Copyright (c) 2017-2023 Roy Marples <roy@marples.name> -->
+
 # dhcpcd
 
 dhcpcd is a

--- a/compat/_strtoi.h
+++ b/compat/_strtoi.h
@@ -1,6 +1,7 @@
 /*	$NetBSD: _strtoi.h,v 1.1 2015/01/22 02:15:59 christos Exp $	*/
 
 /*-
+ * SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/compat/arc4random.c
+++ b/compat/arc4random.c
@@ -1,6 +1,7 @@
 /*	$OpenBSD: arc4random.c,v 1.58 2022/07/31 13:41:45 tb Exp $	*/
 
 /*
+ * SPDX-License-Identifier: ISC
  * Copyright (c) 1996, David Mazieres <dm@uun.org>
  * Copyright (c) 2008, Damien Miller <djm@openbsd.org>
  * Copyright (c) 2013, Markus Friedl <markus@openbsd.org>

--- a/compat/arc4random.h
+++ b/compat/arc4random.h
@@ -1,5 +1,6 @@
 /*
  * Arc4 random number generator for OpenBSD.
+ * SPDX-License-Identifier: ISC
  * Copyright 1996 David Mazieres <dm@lcs.mit.edu>.
  *
  * Modification and redistribution in source and binary forms is

--- a/compat/arc4random_uniform.c
+++ b/compat/arc4random_uniform.c
@@ -1,6 +1,7 @@
 /*	$OpenBSD: arc4random_uniform.c,v 1.3 2019/01/20 02:59:07 bcook Exp $	*/
 
 /*
+ * SPDX-License-Identifier: ISC
  * Copyright (c) 2008, Damien Miller <djm@openbsd.org>
  *
  * Permission to use, copy, modify, and distribute this software for any

--- a/compat/arc4random_uniform.h
+++ b/compat/arc4random_uniform.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: ISC
  * Copyright (c) 2008, Damien Miller <djm@openbsd.org>
  *
  * Permission to use, copy, modify, and distribute this software for any

--- a/compat/bitops.h
+++ b/compat/bitops.h
@@ -1,6 +1,7 @@
 /*	$NetBSD: bitops.h,v 1.11 2012/12/07 02:27:58 christos Exp $	*/
 
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2007, 2010 The NetBSD Foundation, Inc.
  * All rights reserved.
  *

--- a/compat/chacha_private.h
+++ b/compat/chacha_private.h
@@ -1,10 +1,10 @@
-/* SPDX-License-Identifier: CC0-1.0 */
-
 /*
-chacha-merged.c version 20080118
-D. J. Bernstein
-Public domain.
-*/
+ * SPDX-License-Identifier: CC0-1.0
+ *
+ * chacha-merged.c version 20080118
+ * D. J. Bernstein
+ * Public domain.
+ */
 
 /* $OpenBSD: chacha_private.h,v 1.3 2022/02/28 21:56:29 dtucker Exp $ */
 

--- a/compat/chacha_private.h
+++ b/compat/chacha_private.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: CC0-1.0 */
+
 /*
 chacha-merged.c version 20080118
 D. J. Bernstein

--- a/compat/closefrom.h
+++ b/compat/closefrom.h
@@ -1,6 +1,5 @@
 /*
  * SPDX-License-Identifier: ISC
- *
  * Copyright (c) 2004-2005, 2007, 2010, 2012-2015, 2017-2018
  *	Todd C. Miller <Todd.Miller@sudo.ws>
  *

--- a/compat/consttime_memequal.h
+++ b/compat/consttime_memequal.h
@@ -1,6 +1,5 @@
-/* SPDX-License-Identifier: CC0-1.0 */
-
 /*
+ * SPDX-License-Identifier: CC0-1.0
  * Written by Matthias Drochner <drochner@NetBSD.org>.
  * Public domain.
  */

--- a/compat/consttime_memequal.h
+++ b/compat/consttime_memequal.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: CC0-1.0 */
+
 /*
  * Written by Matthias Drochner <drochner@NetBSD.org>.
  * Public domain.

--- a/compat/crypt/hmac.c
+++ b/compat/crypt/hmac.c
@@ -1,6 +1,7 @@
 /*	$NetBSD: hmac.c,v 1.5 2017/10/05 09:59:04 roy Exp $	*/
 
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2016 The NetBSD Foundation, Inc.
  * All rights reserved.
  *

--- a/compat/crypt/hmac.h
+++ b/compat/crypt/hmac.h
@@ -1,6 +1,7 @@
 /*	$NetBSD: hmac.c,v 1.5 2017/10/05 09:59:04 roy Exp $	*/
 
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2016 The NetBSD Foundation, Inc.
  * All rights reserved.
  *

--- a/compat/crypt/md5.c
+++ b/compat/crypt/md5.c
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: CC0-1.0 */
+
 /*
  * This code implements the MD5 message-digest algorithm.
  * The algorithm is due to Ron Rivest.	This code was

--- a/compat/crypt/md5.c
+++ b/compat/crypt/md5.c
@@ -1,6 +1,4 @@
-/* SPDX-License-Identifier: CC0-1.0 */
-
-/*
+/* SPDX-License-Identifier: CC0-1.0
  * This code implements the MD5 message-digest algorithm.
  * The algorithm is due to Ron Rivest.	This code was
  * written by Colin Plumb in 1993, no copyright is claimed.

--- a/compat/crypt/md5.h
+++ b/compat/crypt/md5.h
@@ -1,3 +1,5 @@
+/* SPDX-License-Identifier: CC0-1.0 */
+
 /*
  * This code implements the MD5 message-digest algorithm.
  * The algorithm is due to Ron Rivest.	This code was

--- a/compat/crypt/md5.h
+++ b/compat/crypt/md5.h
@@ -1,8 +1,7 @@
-/* SPDX-License-Identifier: CC0-1.0 */
-
 /*
  * This code implements the MD5 message-digest algorithm.
  * The algorithm is due to Ron Rivest.	This code was
+ * SPDX-License-Identifier: CC0-1.0
  * written by Colin Plumb in 1993, no copyright is claimed.
  * This code is in the public domain; do with it what you wish.
  *

--- a/compat/crypt/md5.h
+++ b/compat/crypt/md5.h
@@ -1,7 +1,7 @@
 /*
  * This code implements the MD5 message-digest algorithm.
- * The algorithm is due to Ron Rivest.	This code was
  * SPDX-License-Identifier: CC0-1.0
+ * The algorithm is due to Ron Rivest.	This code was
  * written by Colin Plumb in 1993, no copyright is claimed.
  * This code is in the public domain; do with it what you wish.
  *

--- a/compat/crypt/sha256.c
+++ b/compat/crypt/sha256.c
@@ -1,4 +1,5 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright 2005 Colin Percival
  * All rights reserved.
  *

--- a/compat/crypt/sha256.h
+++ b/compat/crypt/sha256.h
@@ -1,4 +1,5 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright 2005 Colin Percival
  * All rights reserved.
  *

--- a/compat/crypt_openssl/hmac.c
+++ b/compat/crypt_openssl/hmac.c
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2023 Canonical Ltd.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/compat/crypt_openssl/hmac.h
+++ b/compat/crypt_openssl/hmac.h
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2023 Canonical Ltd.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/compat/crypt_openssl/sha256.c
+++ b/compat/crypt_openssl/sha256.c
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2023 Canonical Ltd.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/compat/crypt_openssl/sha256.h
+++ b/compat/crypt_openssl/sha256.h
@@ -1,5 +1,5 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2023 Canonical Ltd.
  *
  * Redistribution and use in source and binary forms, with or without

--- a/compat/dprintf.c
+++ b/compat/dprintf.c
@@ -1,5 +1,6 @@
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2017 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/compat/dprintf.h
+++ b/compat/dprintf.h
@@ -1,5 +1,6 @@
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2017 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/compat/endian.h
+++ b/compat/endian.h
@@ -1,5 +1,6 @@
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2014 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/compat/pidfile.c
+++ b/compat/pidfile.c
@@ -1,6 +1,7 @@
 /*	$NetBSD: pidfile.c,v 1.16 2021/08/01 15:29:29 andvar Exp $	*/
 
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 1999, 2016 The NetBSD Foundation, Inc.
  * All rights reserved.
  *

--- a/compat/pidfile.h
+++ b/compat/pidfile.h
@@ -1,4 +1,5 @@
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 1999, 2016 The NetBSD Foundation, Inc.
  * All rights reserved.
  *

--- a/compat/queue.h
+++ b/compat/queue.h
@@ -1,3 +1,8 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2014-2025 Roy Marples <roy@marples.name>
+ */
+
 /* This stub exists to avoid including queue.h in the vendor folder
  * for source imports */
 #ifdef BSD

--- a/compat/queue.h
+++ b/compat/queue.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2014-2025 Roy Marples <roy@marples.name>
  */
 

--- a/compat/reallocarray.c
+++ b/compat/reallocarray.c
@@ -1,6 +1,7 @@
 /* $NetBSD: reallocarr.c,v 1.4 2015/08/20 20:08:04 joerg Exp $ */
 
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2015 Joerg Sonnenberger <joerg@NetBSD.org>.
  * All rights reserved.
  *

--- a/compat/reallocarray.h
+++ b/compat/reallocarray.h
@@ -1,6 +1,7 @@
 /* $NetBSD: reallocarr.c,v 1.4 2015/08/20 20:08:04 joerg Exp $ */
 
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2015 Joerg Sonnenberger <joerg@NetBSD.org>.
  * All rights reserved.
  *

--- a/compat/setproctitle.c
+++ b/compat/setproctitle.c
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: MIT
  * Copyright © 2010 William Ahern
  * Copyright © 2012-2013 Guillem Jover <guillem@hadrons.org>
  *

--- a/compat/setproctitle.h
+++ b/compat/setproctitle.h
@@ -1,4 +1,5 @@
 /*
+ * SPDX-License-Identifier: MIT
  * Copyright © 2010 William Ahern
  * Copyright © 2012-2013 Guillem Jover <guillem@hadrons.org>
  *

--- a/compat/strlcpy.c
+++ b/compat/strlcpy.c
@@ -1,6 +1,7 @@
 /*	$OpenBSD: strlcpy.c,v 1.16 2019/01/25 00:19:25 millert Exp $	*/
 
 /*
+ * SPDX-License-Identifier: ISC
  * Copyright (c) 1998, 2015 Todd C. Miller <millert@openbsd.org>
  *
  * Permission to use, copy, modify, and distribute this software for any

--- a/compat/strlcpy.h
+++ b/compat/strlcpy.h
@@ -1,6 +1,7 @@
 /*	$OpenBSD: strlcpy.c,v 1.15 2016/10/16 17:37:39 dtucker Exp $	*/
 
 /*
+ * SPDX-License-Identifier: ISC
  * Copyright (c) 1998, 2015 Todd C. Miller <Todd.Miller@courtesan.com>
  *
  * Permission to use, copy, modify, and distribute this software for any

--- a/compat/strtoi.c
+++ b/compat/strtoi.c
@@ -1,6 +1,7 @@
 /*	$NetBSD: strtoi.c,v 1.3 2019/11/28 12:33:23 roy Exp $	*/
 
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2005 The DragonFly Project.  All rights reserved.
  * Copyright (c) 2003 Citrus Project,
  * All rights reserved.

--- a/compat/strtoi.h
+++ b/compat/strtoi.h
@@ -1,4 +1,5 @@
 /*-
+ * SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/compat/strtou.c
+++ b/compat/strtou.c
@@ -1,6 +1,7 @@
 /*	$NetBSD: strtou.c,v 1.3 2019/11/28 12:33:23 roy Exp $	*/
 
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2005 The DragonFly Project.  All rights reserved.
  * Copyright (c) 2003 Citrus Project,
  * All rights reserved.

--- a/config-null.mk
+++ b/config-null.mk
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2014 Roy Marples <roy@marples.name>
+
 # This space left intentionally blank
 
 DHCPCD_SRCS+=	dhcpcd-embedded.c

--- a/config-null.mk
+++ b/config-null.mk
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2014 Roy Marples <roy@marples.name>
 
 # This space left intentionally blank

--- a/configure
+++ b/configure
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2009-2025 Roy Marples <roy@marples.name>
+
 # Try and be like autotools configure, but without autotools
 
 echo "configure args: $*"

--- a/configure
+++ b/configure
@@ -1,5 +1,5 @@
 #!/bin/sh
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2009-2025 Roy Marples <roy@marples.name>
 
 # Try and be like autotools configure, but without autotools

--- a/hooks/01-test
+++ b/hooks/01-test
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017-2020 Roy Marples <roy@marples.name>
+
 # Echo the interface flags, reason and message options
 
 if [ "$reason" = "TEST" ]; then

--- a/hooks/01-test
+++ b/hooks/01-test
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017-2020 Roy Marples <roy@marples.name>
 
 # Echo the interface flags, reason and message options

--- a/hooks/10-wpa_supplicant
+++ b/hooks/10-wpa_supplicant
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017-2024 Roy Marples <roy@marples.name>
 
 # Start, reconfigure and stop wpa_supplicant per wireless interface.

--- a/hooks/10-wpa_supplicant
+++ b/hooks/10-wpa_supplicant
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017-2024 Roy Marples <roy@marples.name>
+
 # Start, reconfigure and stop wpa_supplicant per wireless interface.
 #
 # This is only needed when using wpa_supplicant-2.5 or older, OR

--- a/hooks/15-timezone
+++ b/hooks/15-timezone
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017-2020 Roy Marples <roy@marples.name>
 
 # Configure timezone

--- a/hooks/15-timezone
+++ b/hooks/15-timezone
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017-2020 Roy Marples <roy@marples.name>
+
 # Configure timezone
 
 : ${localtime:=/etc/localtime}

--- a/hooks/20-resolv.conf
+++ b/hooks/20-resolv.conf
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017-2025 Roy Marples <roy@marples.name>
+
 # Generate /etc/resolv.conf
 # Support resolvconf(8) if available
 # We can merge other dhcpcd resolv.conf files into one like resolvconf,

--- a/hooks/20-resolv.conf
+++ b/hooks/20-resolv.conf
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017-2025 Roy Marples <roy@marples.name>
 
 # Generate /etc/resolv.conf

--- a/hooks/29-lookup-hostname
+++ b/hooks/29-lookup-hostname
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017-2022 Roy Marples <roy@marples.name>
+
 # Lookup the hostname in DNS if not set
 
 lookup_hostname()

--- a/hooks/29-lookup-hostname
+++ b/hooks/29-lookup-hostname
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017-2022 Roy Marples <roy@marples.name>
 
 # Lookup the hostname in DNS if not set

--- a/hooks/30-hostname.in
+++ b/hooks/30-hostname.in
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2020-2024 Roy Marples <roy@marples.name>
+
 # Set the hostname from DHCP data if required
 
 # A hostname can either be a short hostname or a FQDN.

--- a/hooks/30-hostname.in
+++ b/hooks/30-hostname.in
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2020-2024 Roy Marples <roy@marples.name>
 
 # Set the hostname from DHCP data if required

--- a/hooks/50-dhcpcd-compat
+++ b/hooks/50-dhcpcd-compat
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017 Roy Marples <roy@marples.name>
 
 # Compat enter hook shim for older dhcpcd versions

--- a/hooks/50-dhcpcd-compat
+++ b/hooks/50-dhcpcd-compat
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017 Roy Marples <roy@marples.name>
+
 # Compat enter hook shim for older dhcpcd versions
 
 IPADDR=$new_ip_address

--- a/hooks/50-ntp.conf
+++ b/hooks/50-ntp.conf
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017-2026 Roy Marples <roy@marples.name>
+
 # Sample dhcpcd hook script for NTP
 # It will configure either one of NTP, OpenNTP or Chrony (in that order)
 # and will default to NTP if no default config is found.

--- a/hooks/50-ntp.conf
+++ b/hooks/50-ntp.conf
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017-2026 Roy Marples <roy@marples.name>
 
 # Sample dhcpcd hook script for NTP

--- a/hooks/50-timesyncd.conf
+++ b/hooks/50-timesyncd.conf
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2022-2026 Roy Marples <roy@marples.name>
+
 if [ ! -d /run/systemd/system ]; then
 	return
 fi

--- a/hooks/50-timesyncd.conf
+++ b/hooks/50-timesyncd.conf
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2022-2026 Roy Marples <roy@marples.name>
 
 if [ ! -d /run/systemd/system ]; then

--- a/hooks/50-yp.conf
+++ b/hooks/50-yp.conf
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017-2020 Roy Marples <roy@marples.name>
+
 # Sample dhcpcd hook for ypbind
 # This script is only suitable for the Linux version.
 

--- a/hooks/50-yp.conf
+++ b/hooks/50-yp.conf
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017-2020 Roy Marples <roy@marples.name>
 
 # Sample dhcpcd hook for ypbind

--- a/hooks/50-ypbind.in
+++ b/hooks/50-ypbind.in
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017-2021 Roy Marples <roy@marples.name>
+
 # Sample dhcpcd hook for ypbind
 # This script is only suitable for the BSD versions.
 

--- a/hooks/50-ypbind.in
+++ b/hooks/50-ypbind.in
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017-2021 Roy Marples <roy@marples.name>
 
 # Sample dhcpcd hook for ypbind

--- a/hooks/Makefile
+++ b/hooks/Makefile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017-2023 Roy Marples <roy@marples.name>
+
 TOP=	../
 include ${TOP}/iconfig.mk
 

--- a/hooks/Makefile
+++ b/hooks/Makefile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017-2023 Roy Marples <roy@marples.name>
 
 TOP=	../

--- a/hooks/dhcpcd-run-hooks.8.in
+++ b/hooks/dhcpcd-run-hooks.8.in
@@ -1,3 +1,4 @@
+.\" SPDX-License-Identifier: BSD-2-Clause
 .\" Copyright (c) 2006-2025 Roy Marples
 .\" All rights reserved
 .\"

--- a/hooks/dhcpcd-run-hooks.in
+++ b/hooks/dhcpcd-run-hooks.in
@@ -1,5 +1,5 @@
 #!/bin/sh
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017-2022 Roy Marples <roy@marples.name>
 
 # dhcpcd client configuration script 

--- a/hooks/dhcpcd-run-hooks.in
+++ b/hooks/dhcpcd-run-hooks.in
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017-2022 Roy Marples <roy@marples.name>
+
 # dhcpcd client configuration script 
 
 # Handy variables and functions for our hooks to use

--- a/iconfig.mk
+++ b/iconfig.mk
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2014-2019 Roy Marples <roy@marples.name>
 
 # Nasty hack so that make clean works without configure being run

--- a/iconfig.mk
+++ b/iconfig.mk
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2014-2019 Roy Marples <roy@marples.name>
+
 # Nasty hack so that make clean works without configure being run
 TOP?=		.
 _CONFIG_MK!=	test -e ${TOP}/config.mk && \

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017 Roy Marples <roy@marples.name>
+
 # GNU Make does not automagically include .depend
 # Luckily it does read GNUmakefile over Makefile so we can work around it
 

--- a/src/GNUmakefile
+++ b/src/GNUmakefile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017 Roy Marples <roy@marples.name>
 
 # GNU Make does not automagically include .depend

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017-2025 Roy Marples <roy@marples.name>
 
 # dhcpcd Makefile

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017-2025 Roy Marples <roy@marples.name>
+
 # dhcpcd Makefile
 
 PROG=		dhcpcd

--- a/src/arp.c
+++ b/src/arp.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - ARP handler
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/arp.h
+++ b/src/arp.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/auth.c
+++ b/src/auth.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/auth.h
+++ b/src/auth.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/bpf.c
+++ b/src/bpf.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd: BPF arp and bootp filtering
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/bpf.h
+++ b/src/bpf.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd: BPF arp and bootp filtering
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/common.c
+++ b/src/common.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/common.h
+++ b/src/common.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/control.c
+++ b/src/control.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/control.h
+++ b/src/control.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/defs.h
+++ b/src/defs.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/dev.c
+++ b/src/dev.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/dev.h
+++ b/src/dev.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/dev/Makefile
+++ b/src/dev/Makefile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017-2025 Roy Marples <roy@marples.name>
 
 TOP=	../../

--- a/src/dev/Makefile
+++ b/src/dev/Makefile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017-2025 Roy Marples <roy@marples.name>
+
 TOP=	../../
 include ${TOP}/Makefile.inc
 include ${TOP}/config.mk

--- a/src/dev/udev.c
+++ b/src/dev/udev.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  *
  * Redistribution and use in source and binary forms, with or without

--- a/src/dhcp-common.c
+++ b/src/dhcp-common.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/dhcp-common.h
+++ b/src/dhcp-common.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/dhcp.h
+++ b/src/dhcp.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/dhcp6.c
+++ b/src/dhcp6.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/dhcp6.h
+++ b/src/dhcp6.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/dhcpcd-definitions-small.conf
+++ b/src/dhcpcd-definitions-small.conf
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
 # All rights reserved
 

--- a/src/dhcpcd-definitions.conf
+++ b/src/dhcpcd-definitions.conf
@@ -1,3 +1,4 @@
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
 # All rights reserved
 

--- a/src/dhcpcd-embedded.c.in
+++ b/src/dhcpcd-embedded.c.in
@@ -6,6 +6,7 @@
 
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/dhcpcd-embedded.h.in
+++ b/src/dhcpcd-embedded.h.in
@@ -1,5 +1,6 @@
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/dhcpcd.8.in
+++ b/src/dhcpcd.8.in
@@ -1,5 +1,4 @@
 .\" SPDX-License-Identifier: BSD-2-Clause
-.\"
 .\" Copyright (c) 2006-2025 Roy Marples
 .\" All rights reserved
 .\"

--- a/src/dhcpcd.c
+++ b/src/dhcpcd.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/dhcpcd.conf
+++ b/src/dhcpcd.conf
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017-2025 Roy Marples <roy@marples.name>
 
 # A sample configuration for dhcpcd.

--- a/src/dhcpcd.conf
+++ b/src/dhcpcd.conf
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017-2025 Roy Marples <roy@marples.name>
+
 # A sample configuration for dhcpcd.
 # See dhcpcd.conf(5) for details.
 

--- a/src/dhcpcd.conf.5.in
+++ b/src/dhcpcd.conf.5.in
@@ -1,5 +1,4 @@
 .\" SPDX-License-Identifier: BSD-2-Clause
-.\"
 .\" Copyright (c) 2006-2025 Roy Marples
 .\" All rights reserved
 .\"

--- a/src/dhcpcd.h
+++ b/src/dhcpcd.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/duid.c
+++ b/src/duid.c
@@ -1,9 +1,9 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
-
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:

--- a/src/duid.h
+++ b/src/duid.h
@@ -1,9 +1,8 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
-/*
- * dhcpcd - DHCP client daemon
+/* dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
-
+ *
  * Redistribution and use in source and binary forms, with or without
  * modification, are permitted provided that the following conditions
  * are met:

--- a/src/eloop.c
+++ b/src/eloop.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * eloop - portable event based main loop.
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved.
 

--- a/src/eloop.h
+++ b/src/eloop.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/genembedc
+++ b/src/genembedc
@@ -1,5 +1,5 @@
 #!/bin/sh
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017-2020 Roy Marples <roy@marples.name>
 
 set -e

--- a/src/genembedc
+++ b/src/genembedc
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017-2020 Roy Marples <roy@marples.name>
+
 set -e
 
 : ${TOOL_CAT:=cat}

--- a/src/genembedh
+++ b/src/genembedh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017-2019 Roy Marples <roy@marples.name>
 
 set -e

--- a/src/genembedh
+++ b/src/genembedh
@@ -1,4 +1,7 @@
 #!/bin/sh
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017-2019 Roy Marples <roy@marples.name>
+
 set -e
 
 : ${TOOL_SED:=sed}

--- a/src/if-bsd.c
+++ b/src/if-bsd.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * BSD interface driver for dhcpcd
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/if-linux-wext.c
+++ b/src/if-linux-wext.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2009-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/if-linux.c
+++ b/src/if-linux.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Linux interface driver for dhcpcd
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/if-options.c
+++ b/src/if-options.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/if-options.h
+++ b/src/if-options.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/if-sun.c
+++ b/src/if-sun.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Solaris interface driver for dhcpcd
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2016-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/if.c
+++ b/src/if.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/if.h
+++ b/src/if.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/ipv4.h
+++ b/src/ipv4.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/ipv4ll.c
+++ b/src/ipv4ll.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/ipv4ll.h
+++ b/src/ipv4ll.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/ipv6.h
+++ b/src/ipv6.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/ipv6nd.c
+++ b/src/ipv6nd.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - IPv6 ND handling
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/ipv6nd.h
+++ b/src/ipv6nd.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - IPv6 ND handling
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/logerr.c
+++ b/src/logerr.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * logerr: errx with logging
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/logerr.h
+++ b/src/logerr.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * logerr: errx with logging
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/privsep-bpf.c
+++ b/src/privsep-bpf.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Privilege Separation BPF Initiator
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/privsep-bpf.h
+++ b/src/privsep-bpf.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Privilege Separation for dhcpcd
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/privsep-bsd.c
+++ b/src/privsep-bsd.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Privilege Separation for dhcpcd, BSD driver
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/privsep-control.c
+++ b/src/privsep-control.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Privilege Separation for dhcpcd, control proxy
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/privsep-control.h
+++ b/src/privsep-control.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Privilege Separation for dhcpcd
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/privsep-inet.c
+++ b/src/privsep-inet.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Privilege Separation for dhcpcd, network proxy
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/privsep-inet.h
+++ b/src/privsep-inet.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Privilege Separation for dhcpcd
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/privsep-linux.c
+++ b/src/privsep-linux.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Privilege Separation for dhcpcd, Linux driver
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/privsep-root.c
+++ b/src/privsep-root.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Privilege Separation for dhcpcd, privileged proxy
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/privsep-root.h
+++ b/src/privsep-root.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Privilege Separation for dhcpcd
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/privsep-sun.c
+++ b/src/privsep-sun.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Privilege Separation for dhcpcd, Solaris driver
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/privsep.c
+++ b/src/privsep.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Privilege Separation for dhcpcd
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/privsep.h
+++ b/src/privsep.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Privilege Separation for dhcpcd
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/queue.h
+++ b/src/queue.h
@@ -1,5 +1,5 @@
 /*
- * SPDX-License-Identifier: BSD-3-Clause
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2025 Roy Marples <roy@marples.name>
  */
 

--- a/src/queue.h
+++ b/src/queue.h
@@ -1,4 +1,9 @@
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
+ * Copyright (c) 2025 Roy Marples <roy@marples.name>
+ */
+
+/*
  * This stub exists becuase we know a modern BSD supports all TAILQ
  * and glibc, musl et all, don't.
  */

--- a/src/route.c
+++ b/src/route.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - route management
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/route.h
+++ b/src/route.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - route management
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/sa.c
+++ b/src/sa.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Socket Address handling for dhcpcd
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2015-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/sa.h
+++ b/src/sa.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * Socket Address handling for dhcpcd
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2015-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/script.c
+++ b/src/script.c
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/src/script.h
+++ b/src/script.h
@@ -1,6 +1,6 @@
-/* SPDX-License-Identifier: BSD-2-Clause */
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017-2019 Roy Marples <roy@marples.name>
 
 SUBDIRS=	crypt eloop-bench

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017-2019 Roy Marples <roy@marples.name>
+
 SUBDIRS=	crypt eloop-bench
 
 all: 

--- a/tests/crypt/.gitignore
+++ b/tests/crypt/.gitignore
@@ -1,1 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017 Roy Marples <roy@marples.name>
+
 run-test

--- a/tests/crypt/.gitignore
+++ b/tests/crypt/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017 Roy Marples <roy@marples.name>
 
 run-test

--- a/tests/crypt/GNUmakefile
+++ b/tests/crypt/GNUmakefile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017 Roy Marples <roy@marples.name>
+
 # GNU Make does not automagically include .depend
 # Luckily it does read GNUmakefile over Makefile so we can work around it
 

--- a/tests/crypt/GNUmakefile
+++ b/tests/crypt/GNUmakefile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017 Roy Marples <roy@marples.name>
 
 # GNU Make does not automagically include .depend

--- a/tests/crypt/Makefile
+++ b/tests/crypt/Makefile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017-2023 Roy Marples <roy@marples.name>
 
 TOP=	../..

--- a/tests/crypt/Makefile
+++ b/tests/crypt/Makefile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017-2023 Roy Marples <roy@marples.name>
+
 TOP=	../..
 include ${TOP}/iconfig.mk
 

--- a/tests/crypt/README.md
+++ b/tests/crypt/README.md
@@ -1,3 +1,6 @@
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
+<!-- Copyright (c) 2017 Roy Marples <roy@marples.name> -->
+
 # dhcpcd Test Suite
 
 Currently this just tests the RFC2202 MD5 implementation in dhcpcd.

--- a/tests/crypt/README.md
+++ b/tests/crypt/README.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: BSD-3-Clause -->
+<!-- SPDX-License-Identifier: BSD-2-Clause -->
 <!-- Copyright (c) 2017 Roy Marples <roy@marples.name> -->
 
 # dhcpcd Test Suite

--- a/tests/crypt/run-test.c
+++ b/tests/crypt/run-test.c
@@ -1,5 +1,6 @@
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2018 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/tests/crypt/test.h
+++ b/tests/crypt/test.h
@@ -1,5 +1,6 @@
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2018 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/tests/crypt/test_hmac_md5.c
+++ b/tests/crypt/test_hmac_md5.c
@@ -1,5 +1,6 @@
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2018 Roy Marples <roy@marples.name>
  * All rights reserved
 

--- a/tests/crypt/test_sha256.c
+++ b/tests/crypt/test_sha256.c
@@ -1,5 +1,6 @@
 /*
  * dhcpcd - DHCP client daemon
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2023 Tobias Heider <tobias.heider@canonical.com>
  * Copyright (c) 2006-2018 Roy Marples <roy@marples.name>
  * All rights reserved

--- a/tests/eloop-bench/.gitignore
+++ b/tests/eloop-bench/.gitignore
@@ -1,1 +1,4 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017 Roy Marples <roy@marples.name>
+
 eloop-bench

--- a/tests/eloop-bench/.gitignore
+++ b/tests/eloop-bench/.gitignore
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017 Roy Marples <roy@marples.name>
 
 eloop-bench

--- a/tests/eloop-bench/Makefile
+++ b/tests/eloop-bench/Makefile
@@ -1,4 +1,4 @@
-# SPDX-License-Identifier: BSD-3-Clause
+# SPDX-License-Identifier: BSD-2-Clause
 # Copyright (c) 2017-2023 Roy Marples <roy@marples.name>
 
 TOP=	../..

--- a/tests/eloop-bench/Makefile
+++ b/tests/eloop-bench/Makefile
@@ -1,3 +1,6 @@
+# SPDX-License-Identifier: BSD-3-Clause
+# Copyright (c) 2017-2023 Roy Marples <roy@marples.name>
+
 TOP=	../..
 include ${TOP}/iconfig.mk
 

--- a/tests/eloop-bench/README.md
+++ b/tests/eloop-bench/README.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: BSD-3-Clause -->
+<!-- SPDX-License-Identifier: BSD-2-Clause -->
 <!-- Copyright (c) 2017 Roy Marples <roy@marples.name> -->
 
 # eloop-bench

--- a/tests/eloop-bench/README.md
+++ b/tests/eloop-bench/README.md
@@ -1,3 +1,6 @@
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
+<!-- Copyright (c) 2017 Roy Marples <roy@marples.name> -->
+
 # eloop-bench
 
 eloop is a portable event loop designed to be dropped into the code of a

--- a/tests/eloop-bench/eloop-bench.c
+++ b/tests/eloop-bench/eloop-bench.c
@@ -1,5 +1,6 @@
 /*
  * eloop benchmark
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2024 Roy Marples <roy@marples.name>
  * All rights reserved.
 

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,4 +1,4 @@
-<!-- SPDX-License-Identifier: BSD-3-Clause -->
+<!-- SPDX-License-Identifier: BSD-2-Clause -->
 <!-- Copyright (c) 2025 Roy Marples <roy@marples.name> -->
 
 This area is for 3rd party software we include directly.

--- a/vendor/README.md
+++ b/vendor/README.md
@@ -1,3 +1,6 @@
+<!-- SPDX-License-Identifier: BSD-3-Clause -->
+<!-- Copyright (c) 2025 Roy Marples <roy@marples.name> -->
+
 This area is for 3rd party software we include directly.
 All imports should be made on a branch vendor/NAME (initially orphaned) and
 merged into the master branch.

--- a/vendor/queue.h
+++ b/vendor/queue.h
@@ -1,6 +1,7 @@
 /*	$NetBSD: queue.h,v 1.77 2024/05/12 10:34:56 rillig Exp $	*/
 
 /*
+ * SPDX-License-Identifier: BSD-3-Clause
  * Copyright (c) 1991, 1993
  *	The Regents of the University of California.  All rights reserved.
  *

--- a/vendor/rbtree.c
+++ b/vendor/rbtree.c
@@ -1,6 +1,7 @@
 /*	$NetBSD: rbtree.c,v 1.2 2025/10/29 08:08:44 roy Exp $	*/
 
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2001 The NetBSD Foundation, Inc.
  * All rights reserved.
  *

--- a/vendor/rbtree.h
+++ b/vendor/rbtree.h
@@ -1,6 +1,7 @@
 /*	$NetBSD: rbtree.h,v 1.14 2025/10/29 08:08:44 roy Exp $	*/
 
 /*-
+ * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2001 The NetBSD Foundation, Inc.
  * All rights reserved.
  *


### PR DESCRIPTION
If copyright block is present, add missing SPDX-License tag

If copyright block is not present, add one. Use BSD-3-Clause and infer author list from git blame.

Resolves #570
