### PR TITLE
Delete DHCPv6 IA FD from the loop before closing it

### DIFF
--- a/src/eloop.c
+++ b/src/eloop.c
@@ -385,6 +385,7 @@ eloop_event_delete(struct eloop *eloop, int fd)
 	struct kevent ke[2], *kep = &ke[0];
 	size_t n;
 #endif
+	int error;
 
 	if (fd == -1) {
 		errno = EINVAL;
@@ -400,6 +401,7 @@ eloop_event_delete(struct eloop *eloop, int fd)
 		return -1;
 	}
 
+	error = 1;
 #if defined(USE_KQUEUE)
 	n = 0;
 	if (e->events & ELE_READ) {
@@ -411,16 +413,18 @@ eloop_event_delete(struct eloop *eloop, int fd)
 		n++;
 	}
 	if (n != 0 && kevent(eloop->fd, ke, (KEVENT_N)n, NULL, 0, NULL) == -1)
-		return -1;
+		error = -1;
 #elif defined(USE_EPOLL)
 	if (epoll_ctl(eloop->fd, EPOLL_CTL_DEL, fd, NULL) == -1)
-		return -1;
+		error = -1;
 #endif
 
+	/* We should remove the event from the eloop even if kevent or epoll
+	 * report an error, it's possible it could be EBADF for example. */
 	e->fd = -1;
 	eloop->nevents--;
 	eloop->events_need_setup = true;
-	return 1;
+	return error;
 }
 
 unsigned long long

--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -1023,8 +1023,8 @@ ipv6_freeaddr(struct ipv6_addr *ia)
 #endif
 
 	if (ia->dhcp6_fd != -1) {
-		close(ia->dhcp6_fd);
 		eloop_event_delete(eloop, ia->dhcp6_fd);
+		close(ia->dhcp6_fd);
 	}
 
 	eloop_q_timeout_delete(eloop, ELOOP_QUEUE_ALL, NULL, ia);


### PR DESCRIPTION
Otherwise the eloop code gets confused.
If eloop fails to delete a fd for any reason, it should still remove it from the internal list.