### PR TITLE
dhcp-common: Escape ifname for lease file

### DIFF
--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -12,4 +12,4 @@ jobs:
       - uses: RafikFarhad/clang-format-github-action@v5
         with:
           style: "file"
-          sources: "src/**/*.h,src/**/*.c"
+          sources: "src/*.h,src/*.c,src/**/*.h,src/**/*.c"

--- a/src/bpf-dlpi.c
+++ b/src/bpf-dlpi.c
@@ -27,6 +27,7 @@
  */
 
 #include <sys/types.h>
+
 #include <net/if.h>
 #include <netinet/if_ether.h>
 
@@ -35,8 +36,8 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "bpf.h"
 #include "bpf-dlpi.h"
+#include "bpf.h"
 
 struct bpf_dlpi {
 	dlpi_handle_t bd_handle;

--- a/src/bpf-linux.c
+++ b/src/bpf-linux.c
@@ -28,11 +28,10 @@
 #include <sys/ioctl.h>
 #include <sys/socket.h>
 
+#include <errno.h>
+#include <linux/filter.h>
 #include <linux/if_ether.h>
 #include <linux/if_packet.h>
-#include <linux/filter.h>
-
-#include <errno.h>
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>
@@ -184,7 +183,8 @@ bpf_setfilter(const struct bpf *bpf, void *filter, unsigned int filter_len)
 }
 
 int
-bpf_setwfilter(__unused const struct bpf *bpf, __unused void *filter, __unused unsigned int filter_len)
+bpf_setwfilter(__unused const struct bpf *bpf, __unused void *filter,
+    __unused unsigned int filter_len)
 {
 #warning A compromised PF_PACKET socket can be used as a raw socket
 
@@ -220,4 +220,3 @@ bpf_close(struct bpf *bpf)
 	free(bpf->bpf_buffer);
 	free(bpf);
 }
-

--- a/src/dhcp-common.c
+++ b/src/dhcp-common.c
@@ -855,13 +855,14 @@ dhcp_set_leasefile(char *leasefile, size_t len, int family,
 		return -1;
 	}
 
-	if (print_string(ifname, sizeof(ifname), OT_ESCFILE, ifp->name, strlen(ifp->name)) == -1)
+	if (print_string(ifname, sizeof(ifname), OT_ESCFILE, ifp->name,
+		strlen(ifp->name)) == -1)
 		return -1;
 
 	if (ifp->wireless) {
 		ssid[0] = '-';
 		if (print_string(ssid + 1, sizeof(ssid) - 1, OT_ESCFILE,
-		    ifp->ssid, ifp->ssid_len) == -1)
+			ifp->ssid, ifp->ssid_len) == -1)
 			return -1;
 	} else
 		ssid[0] = '\0';

--- a/src/dhcp-common.c
+++ b/src/dhcp-common.c
@@ -855,11 +855,14 @@ dhcp_set_leasefile(char *leasefile, size_t len, int family,
 		return -1;
 	}
 
-	print_string(ifname, sizeof(ifname), OT_ESCFILE, ifp->name, strlen(ifp->name));
+	if (print_string(ifname, sizeof(ifname), OT_ESCFILE, ifp->name, strlen(ifp->name)) == -1)
+		return -1;
+
 	if (ifp->wireless) {
 		ssid[0] = '-';
-		print_string(ssid + 1, sizeof(ssid) - 1, OT_ESCFILE,
-		    ifp->ssid, ifp->ssid_len);
+		if (print_string(ssid + 1, sizeof(ssid) - 1, OT_ESCFILE,
+		    ifp->ssid, ifp->ssid_len) == -1)
+			return -1;
 	} else
 		ssid[0] = '\0';
 	return snprintf(leasefile, len,

--- a/src/dhcp-common.c
+++ b/src/dhcp-common.c
@@ -838,6 +838,7 @@ int
 dhcp_set_leasefile(char *leasefile, size_t len, int family,
     const struct interface *ifp)
 {
+	char ifname[(sizeof(ifp->name) * 4) + 1];
 	char ssid[1 + (IF_SSIDLEN * 4) + 1]; /* - prefix and NUL terminated. */
 
 	if (ifp->name[0] == '\0') {
@@ -854,6 +855,7 @@ dhcp_set_leasefile(char *leasefile, size_t len, int family,
 		return -1;
 	}
 
+	print_string(ifname, sizeof(ifname), OT_ESCFILE, ifp->name, strlen(ifp->name));
 	if (ifp->wireless) {
 		ssid[0] = '-';
 		print_string(ssid + 1, sizeof(ssid) - 1, OT_ESCFILE,
@@ -861,7 +863,7 @@ dhcp_set_leasefile(char *leasefile, size_t len, int family,
 	} else
 		ssid[0] = '\0';
 	return snprintf(leasefile, len,
-	    family == AF_INET ? LEASEFILE : LEASEFILE6, ifp->name, ssid);
+	    family == AF_INET ? LEASEFILE : LEASEFILE6, ifname, ssid);
 }
 
 void

--- a/src/dhcpcd.c
+++ b/src/dhcpcd.c
@@ -2289,7 +2289,8 @@ main(int argc, char **argv, char **envp)
 			default:
 				per = "";
 			}
-			if (asprintf(&ctx.pidfile, PIDFILE, ifname, per, ".") == -1) {
+			if (asprintf(&ctx.pidfile, PIDFILE, ifname, per, ".") ==
+			    -1) {
 				logerr("%s: asprintf", __func__);
 				goto exit_failure;
 			}

--- a/src/eloop.c
+++ b/src/eloop.c
@@ -1001,7 +1001,7 @@ eloop_closefdwaiter(struct eloop *eloop)
 #if defined(USE_KQUEUE) || defined(USE_EPOLL)
 	int err;
 
-        if (eloop->waitfd == -1) {
+	if (eloop->waitfd == -1) {
 		errno = EBADF;
 		return -1;
 	}

--- a/src/if-bsd.c
+++ b/src/if-bsd.c
@@ -104,8 +104,9 @@ struct vlanreq {
 
 #ifndef RT_ROUNDUP
 #ifdef __APPLE__
-#define RT_ROUNDUP(a) \
-	((a) > 0 ? (1 + (((a) - 1) | (sizeof(uint32_t) - 1))) : sizeof(uint32_t))
+#define RT_ROUNDUP(a)                                           \
+	((a) > 0 ? (1 + (((a) - 1) | (sizeof(uint32_t) - 1))) : \
+		   sizeof(uint32_t))
 #else
 #define RT_ROUNDUP(a) \
 	((a) > 0 ? (1 + (((a) - 1) | (sizeof(long) - 1))) : sizeof(long))
@@ -834,7 +835,8 @@ if_route(unsigned char cmd, const struct rt *rt)
 			if_copysa(gsa, rt->rt_gateway);
 #ifdef INET6
 			if (gss.ss_family == AF_INET6)
-				ipv6_setscope((struct sockaddr_in6 *)&gss, rt->rt_ifp->index);
+				ipv6_setscope((struct sockaddr_in6 *)&gss,
+				    rt->rt_ifp->index);
 #endif
 			ADDSA(gsa);
 		}
@@ -1337,7 +1339,8 @@ if_rtm(struct dhcpcd_ctx *ctx, const struct rt_msghdr *rtm)
 	    (rt.rt_flags & RTF_HOST || rtm->rtm_type == RTM_MISS) &&
 	    !(rtm->rtm_type == RTM_ADD && !(rt.rt_dflags & RTDF_GATELINK))) {
 		bool reachable;
-		struct sockaddr_in6 *dest = (struct sockaddr_in6 *)&rt.rt_ss_dest;
+		struct sockaddr_in6 *dest =
+		    (struct sockaddr_in6 *)&rt.rt_ss_dest;
 
 		reachable = (rtm->rtm_type == RTM_ADD ||
 				rtm->rtm_type == RTM_CHANGE) &&

--- a/src/if-linux.c
+++ b/src/if-linux.c
@@ -702,7 +702,7 @@ if_copyrt(struct dhcpcd_ctx *ctx, struct rt *rt, struct nlmsghdr *nlm)
 			sa = rt->rt_dest;
 			break;
 		case RTA_SRC: {
-			struct sockaddr_storage ss;	
+			struct sockaddr_storage ss;
 			struct sockaddr *psa = (struct sockaddr *)&ss;
 			socklen_t salen;
 

--- a/src/if-sun.c
+++ b/src/if-sun.c
@@ -27,8 +27,6 @@
  */
 
 /* Stop sunos headers including the system queue ... */
-#include "queue.h"
-
 #include <sys/ioctl.h>
 #include <sys/mac.h>
 #include <sys/pfmod.h>
@@ -38,9 +36,9 @@
 #include <net/if.h>
 #include <net/if_dl.h>
 #include <net/if_types.h>
-#include <netinet/if_ether.h>
 #include <netinet/in.h>
 #include <netinet/udp.h>
+#include <netinet/if_ether.h>
 
 #include <assert.h>
 #include <errno.h>
@@ -54,6 +52,8 @@
 #include <string.h>
 #include <stropts.h>
 #include <unistd.h>
+
+#include "queue.h"
 
 /* Private libsocket interface we can hook into to get
  * a better getifaddrs(3).

--- a/src/privsep-root.c
+++ b/src/privsep-root.c
@@ -931,10 +931,8 @@ ps_root_stop(struct dhcpcd_ctx *ctx)
 		/* drain the log */
 		if (ctx->ps_log_root_fd != -1) {
 			ssize_t loglen;
-			struct pollfd pfd = {
-				.fd = ctx->ps_log_root_fd,
-				.events = POLLIN
-			};
+			struct pollfd pfd = { .fd = ctx->ps_log_root_fd,
+				.events = POLLIN };
 			int n;
 
 			/* the socket is blocking and we may not be able to

--- a/src/privsep.c
+++ b/src/privsep.c
@@ -1108,8 +1108,7 @@ ps_recvpsmsg(struct dhcpcd_ctx *ctx, int fd, unsigned short events,
 		return len;
 	}
 
-	cmsg_padlen = CALC_CMSG_PADLEN(psm.ps_controllen,
-	    psm.ps_namelen);
+	cmsg_padlen = CALC_CMSG_PADLEN(psm.ps_controllen, psm.ps_namelen);
 	dlen = psm.ps_namelen + psm.ps_controllen + cmsg_padlen +
 	    psm.ps_datalen;
 	if (dlen != 0) {


### PR DESCRIPTION
It's possible a characters allowed in an interface name aren't shell or human readable on some OS.