### PR TITLE
script: Use correct buffer length variable

### DIFF
--- a/src/script.c
+++ b/src/script.c
@@ -787,7 +787,7 @@ send_listeners:
 	TAILQ_FOREACH(fd, &ctx->control_fds, next) {
 		if (!(fd->flags & FD_LISTEN))
 			continue;
-		if (control_queue(fd, ctx->script_buf, ctx->script_buflen) ==
+		if (control_queue(fd, ctx->script_buf, (size_t)buflen) ==
 		    -1)
 			logerr("%s: control_queue", __func__);
 		else

--- a/src/script.c
+++ b/src/script.c
@@ -1,4 +1,3 @@
-/*
  * dhcpcd - DHCP client daemon
  * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>
@@ -787,8 +786,7 @@ send_listeners:
 	TAILQ_FOREACH(fd, &ctx->control_fds, next) {
 		if (!(fd->flags & FD_LISTEN))
 			continue;
-		if (control_queue(fd, ctx->script_buf, (size_t)buflen) ==
-		    -1)
+		if (control_queue(fd, ctx->script_buf, (size_t)buflen) == -1)
 			logerr("%s: control_queue", __func__);
 		else
 			status = 1;

--- a/src/script.c
+++ b/src/script.c
@@ -1,3 +1,4 @@
+/*
  * dhcpcd - DHCP client daemon
  * SPDX-License-Identifier: BSD-2-Clause
  * Copyright (c) 2006-2025 Roy Marples <roy@marples.name>


### PR DESCRIPTION
Final call to the control queue used the wrong 'buflen' variable. Change so the function stays consistent.