### PR TITLE
hooks: don't read past truncated ip6 address starting fe

### DIFF
--- a/src/dhcp-common.c
+++ b/src/dhcp-common.c
@@ -825,7 +825,8 @@ print_option(FILE *fp, const char *prefix, const struct dhcp_opt *opt,
 				goto err;
 			if (fprintf(fp, "%s", buf) == -1)
 				goto err;
-			if (data[0] == 0xfe && (data[1] & 0xc0) == 0x80) {
+			if (datalen >= 2 && data[0] == 0xfe &&
+			    (data[1] & 0xc0) == 0x80) {
 				if (fprintf(fp, "%%%s", ifname) == -1)
 					goto err;
 			}


### PR DESCRIPTION
We want to append the interface name to link-local addresses. But we might get a truncated address as well and an attacker could just supply the fe part. In this case, ensure we have enough of the address to read the next byte otherwise don't append the interface name.

Reported by NVIDIA Project Vanessa