### PR TITLE
DHCP6: Fix configuring the suffix to delegated prefixes

### DIFF
--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -590,7 +590,7 @@ ipv6_userprefix(const struct in6_addr *prefix, // prefix from router
 		if (prefix_len >= 64)
 			user_high = 0;
 		else
-			user_high = user_number >> (result_len - prefix_len);
+			user_high = user_number >> (result_len - 64);
 		user_low = user_number << (128 - result_len);
 	} else if (result_len == 64) {
 		user_high = user_number;


### PR DESCRIPTION
Depending on the delegated prefix length and the user configured suffix length, some parts of the suffix would be lost.

Reported by NVIDIA Project Vanessa