### PR TITLE
IPv6: Fix numerous issues extending temporary address times

### DIFF
--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -1985,13 +1985,13 @@ ipv6_settemptime(struct ipv6_addr *ia, int flags)
 	TAILQ_FOREACH_REVERSE(ap, &state->addrs, ipv6_addrhead, next) {
 		if (ap->flags & IPV6_AF_TEMPORARY && ap->prefix_pltime &&
 		    IN6_ARE_ADDR_EQUAL(&ia->prefix, &ap->prefix)) {
-			unsigned int max, ext;
+			uint32_t elapsed, limit;
 
 			if (flags == 0) {
-				if (ap->prefix_pltime -
-					(uint32_t)(ia->acquired.tv_sec -
-					    ap->acquired.tv_sec) <
-				    REGEN_ADVANCE)
+				elapsed = (uint32_t)eloop_timespec_diff(
+				    &ia->acquired, &ap->acquired, NULL);
+				if (ap->prefix_pltime <= elapsed ||
+				    ap->prefix_pltime - elapsed < REGEN_ADVANCE)
 					continue;
 
 				return ap;
@@ -2000,6 +2000,9 @@ ipv6_settemptime(struct ipv6_addr *ia, int flags)
 			if (!(ap->flags & IPV6_AF_ADDED))
 				ap->flags |= IPV6_AF_NEW | IPV6_AF_AUTOCONF;
 			ap->flags &= ~IPV6_AF_STALE;
+
+			elapsed = (uint32_t)eloop_timespec_diff(
+			    &ia->acquired, &ap->created, NULL);
 
 			/* RFC4941 Section 3.4
 			 * Deprecated prefix, deprecate the temporary address */
@@ -2014,26 +2017,22 @@ ipv6_settemptime(struct ipv6_addr *ia, int flags)
 			/* RFC4941 Section 3.3.2
 			 * Extend temporary times, but ensure that they
 			 * never last beyond the system limit. */
-			ext = (unsigned int)ia->acquired.tv_sec +
-			    ia->prefix_pltime;
-			max = (unsigned int)(ap->created.tv_sec +
-			    TEMP_PREFERRED_LIFETIME - state->desync_factor);
-			if (ext < max)
+			limit = TEMP_PREFERRED_LIFETIME - state->desync_factor;
+			if (elapsed >= limit)
+				ap->prefix_pltime = 0;
+			else if (ia->prefix_pltime < limit - elapsed)
 				ap->prefix_pltime = ia->prefix_pltime;
 			else
-				ap->prefix_pltime = (uint32_t)(max -
-				    ia->acquired.tv_sec);
+				ap->prefix_pltime = limit - elapsed;
 
 		valid:
-			ext = (unsigned int)ia->acquired.tv_sec +
-			    ia->prefix_vltime;
-			max = (unsigned int)(ap->created.tv_sec +
-			    TEMP_VALID_LIFETIME);
-			if (ext < max)
+			limit = TEMP_VALID_LIFETIME;
+			if (elapsed >= limit)
+				ap->prefix_vltime = 0;
+			else if (ia->prefix_vltime < limit - elapsed)
 				ap->prefix_vltime = ia->prefix_vltime;
 			else
-				ap->prefix_vltime = (uint32_t)(max -
-				    ia->acquired.tv_sec);
+				ap->prefix_vltime = limit - elapsed;
 
 			/* Just extend the latest matching prefix */
 			ap->acquired = ia->acquired;

--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -1989,8 +1989,8 @@ ipv6_settemptime(struct ipv6_addr *ia, int flags)
 			uint32_t limit, rmtime;
 
 			if (flags == 0) {
-				elapsed = eloop_timespec_diff(
-				    &ia->acquired, &ap->acquired, NULL);
+				elapsed = eloop_timespec_diff(&ia->acquired,
+				    &ap->acquired, NULL);
 				if (ap->prefix_pltime <= elapsed ||
 				    ap->prefix_pltime - elapsed < REGEN_ADVANCE)
 					continue;

--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -2019,23 +2019,27 @@ ipv6_settemptime(struct ipv6_addr *ia, int flags)
 			 * Extend temporary times, but ensure that they
 			 * never last beyond the system limit. */
 			limit = TEMP_PREFERRED_LIFETIME - state->desync_factor;
-			rmtime = (uint32_t)(limit - elapsed);
 			if (elapsed >= limit)
 				ap->prefix_pltime = 0;
-			else if (ia->prefix_pltime < rmtime)
-				ap->prefix_pltime = ia->prefix_pltime;
-			else
-				ap->prefix_pltime = rmtime;
+			else {
+				rmtime = (uint32_t)(limit - elapsed);
+				if (ia->prefix_pltime < rmtime)
+					ap->prefix_pltime = ia->prefix_pltime;
+				else
+					ap->prefix_pltime = rmtime;
+			}
 
 		valid:
 			limit = TEMP_VALID_LIFETIME;
-			rmtime = (uint32_t)(limit - elapsed);
 			if (elapsed >= limit)
 				ap->prefix_vltime = 0;
-			else if (ia->prefix_vltime < rmtime)
-				ap->prefix_vltime = ia->prefix_vltime;
-			else
-				ap->prefix_vltime = rmtime;
+			else {
+				rmtime = (uint32_t)(limit - elapsed);
+				if (ia->prefix_vltime < rmtime)
+					ap->prefix_vltime = ia->prefix_vltime;
+				else
+					ap->prefix_vltime = rmtime;
+			}
 
 			/* Just extend the latest matching prefix */
 			ap->acquired = ia->acquired;

--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -1985,10 +1985,11 @@ ipv6_settemptime(struct ipv6_addr *ia, int flags)
 	TAILQ_FOREACH_REVERSE(ap, &state->addrs, ipv6_addrhead, next) {
 		if (ap->flags & IPV6_AF_TEMPORARY && ap->prefix_pltime &&
 		    IN6_ARE_ADDR_EQUAL(&ia->prefix, &ap->prefix)) {
-			uint32_t elapsed, limit;
+			unsigned long long elapsed;
+			uint32_t limit, rmtime;
 
 			if (flags == 0) {
-				elapsed = (uint32_t)eloop_timespec_diff(
+				elapsed = eloop_timespec_diff(
 				    &ia->acquired, &ap->acquired, NULL);
 				if (ap->prefix_pltime <= elapsed ||
 				    ap->prefix_pltime - elapsed < REGEN_ADVANCE)
@@ -2001,8 +2002,8 @@ ipv6_settemptime(struct ipv6_addr *ia, int flags)
 				ap->flags |= IPV6_AF_NEW | IPV6_AF_AUTOCONF;
 			ap->flags &= ~IPV6_AF_STALE;
 
-			elapsed = (uint32_t)eloop_timespec_diff(
-			    &ia->acquired, &ap->created, NULL);
+			elapsed = eloop_timespec_diff(&ia->acquired,
+			    &ap->created, NULL);
 
 			/* RFC4941 Section 3.4
 			 * Deprecated prefix, deprecate the temporary address */
@@ -2018,21 +2019,23 @@ ipv6_settemptime(struct ipv6_addr *ia, int flags)
 			 * Extend temporary times, but ensure that they
 			 * never last beyond the system limit. */
 			limit = TEMP_PREFERRED_LIFETIME - state->desync_factor;
+			rmtime = (uint32_t)(limit - elapsed);
 			if (elapsed >= limit)
 				ap->prefix_pltime = 0;
-			else if (ia->prefix_pltime < limit - elapsed)
+			else if (ia->prefix_pltime < rmtime)
 				ap->prefix_pltime = ia->prefix_pltime;
 			else
-				ap->prefix_pltime = limit - elapsed;
+				ap->prefix_pltime = rmtime;
 
 		valid:
 			limit = TEMP_VALID_LIFETIME;
+			rmtime = (uint32_t)(limit - elapsed);
 			if (elapsed >= limit)
 				ap->prefix_vltime = 0;
-			else if (ia->prefix_vltime < limit - elapsed)
+			else if (ia->prefix_vltime < rmtime)
 				ap->prefix_vltime = ia->prefix_vltime;
 			else
-				ap->prefix_vltime = limit - elapsed;
+				ap->prefix_vltime = rmtime;
 
 			/* Just extend the latest matching prefix */
 			ap->acquired = ia->acquired;


### PR DESCRIPTION
Fix a potential integer underflow if pltime is less than aquisition time.
Fix potential time truncation to uint32_t.

Reported by NVIDIA Project Vanessa