### PR TITLE
dhcpcd 10.3 CVE-2026-56114 and 56116

### DIFF
--- a/src/dhcp6.c
+++ b/src/dhcp6.c
@@ -1093,7 +1093,7 @@ dhcp6_makemessage(struct interface *ifp)
 
 				/* RFC6603 Section 4.2 */
 				if (ap->prefix_exclude_len) {
-					uint8_t exb[16], *ep, u8;
+					uint8_t exb[17], *ep, u8;
 					const uint8_t *pp;
 
 					n = (size_t)((ap->prefix_exclude_len -

--- a/src/eloop.c
+++ b/src/eloop.c
@@ -385,6 +385,7 @@ eloop_event_delete(struct eloop *eloop, int fd)
 	struct kevent ke[2], *kep = &ke[0];
 	size_t n;
 #endif
+	int error;
 
 	if (fd == -1) {
 		errno = EINVAL;
@@ -400,6 +401,7 @@ eloop_event_delete(struct eloop *eloop, int fd)
 		return -1;
 	}
 
+	error = 1;
 #if defined(USE_KQUEUE)
 	n = 0;
 	if (e->events & ELE_READ) {
@@ -411,16 +413,18 @@ eloop_event_delete(struct eloop *eloop, int fd)
 		n++;
 	}
 	if (n != 0 && kevent(eloop->fd, ke, (KEVENT_N)n, NULL, 0, NULL) == -1)
-		return -1;
+		error = -1;
 #elif defined(USE_EPOLL)
 	if (epoll_ctl(eloop->fd, EPOLL_CTL_DEL, fd, NULL) == -1)
-		return -1;
+		error = -1;
 #endif
 
+	/* We should remove the event from the eloop even if kevent or epoll
+	 * report an error, it's possible it could be EBADF for example. */
 	e->fd = -1;
 	eloop->nevents--;
 	eloop->events_need_setup = true;
-	return 1;
+	return error;
 }
 
 unsigned long long

--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -1046,8 +1046,8 @@ ipv6_freeaddr(struct ipv6_addr *ia)
 #endif
 
 	if (ia->dhcp6_fd != -1) {
-		close(ia->dhcp6_fd);
 		eloop_event_delete(eloop, ia->dhcp6_fd);
+		close(ia->dhcp6_fd);
 	}
 
 	eloop_q_timeout_delete(eloop, ELOOP_QUEUE_ALL, NULL, ia);

--- a/src/ipv6nd.c
+++ b/src/ipv6nd.c
@@ -1789,6 +1789,7 @@ ipv6nd_expirera(void *arg)
 				logwarnx("%s: expired route %s",
 				    rap->iface->name, rinfo->sprefix);
 				TAILQ_REMOVE(&rap->rinfos, rinfo, next);
+				free(rinfo);
 			}
 		}
 

--- a/src/script.c
+++ b/src/script.c
@@ -793,7 +793,7 @@ send_listeners:
 	TAILQ_FOREACH(fd, &ctx->control_fds, next) {
 		if (!(fd->flags & FD_LISTEN))
 			continue;
-		if (control_queue(fd, ctx->script_buf, ctx->script_buflen)== -1)
+		if (control_queue(fd, ctx->script_buf, (size_t)buflen) == -1)
 			logerr("%s: control_queue", __func__);
 		else
 			status = 1;


### PR DESCRIPTION
- **DHCPv6: Prefix exclude option can be 17 octets (#671)**
https://www.cve.org/CVERecord?id=CVE-2026-56114

- **IPv6ND: Free routeinfo when it expires (#670)**
https://www.cve.org/CVERecord?id=CVE-2026-56116