### PR TITLE
options: Introdce policy groups

### DIFF
--- a/src/dhcp-common.c
+++ b/src/dhcp-common.c
@@ -147,6 +147,23 @@ dhcp_print_option_encoding(const struct dhcp_opt *opt, int cols)
 	fflush(stdout);
 }
 
+static char dhcp_option_string_buf[16];
+const char *
+dhcp_option_string(const struct dhcp_opt *opts, size_t nopts, uint32_t option)
+{
+	size_t n;
+
+	for (n = 0; n < nopts; n++, opts++) {
+		if (opts->option == option)
+			return opts->var;
+	}
+
+	if (snprintf(dhcp_option_string_buf, sizeof(dhcp_option_string_buf),
+		"%u", option) == -1)
+		return NULL;
+	return dhcp_option_string_buf;
+}
+
 struct dhcp_opt *
 vivso_find(uint32_t iana_en, const void *arg)
 {
@@ -192,13 +209,107 @@ dhcp_vendor(char *str, size_t len)
 }
 
 int
-make_option_mask(const struct dhcp_opt *dopts, size_t dopts_len,
-    const struct dhcp_opt *odopts, size_t odopts_len, uint8_t *mask,
+dho_policy_has(const struct dho_policy *policy, uint32_t option)
+{
+	size_t i;
+
+	for (i = 0; i < policy->dhop_policy_len; i++) {
+		if (policy->dhop_policy[i] == option)
+			return 1;
+	}
+
+	return 0;
+}
+
+int
+dho_policy_allowed(const struct dho_policy_group *pg, uint32_t option)
+{
+	if (pg->dhop_allow.dhop_policy_len == 0) {
+		/* No allowed policy has been set, so be permissive. */
+		return dho_policy_has(&pg->dhop_remove, option) ? 0 : 1;
+	}
+
+	if (dho_policy_has(&pg->dhop_allow, option) ||
+	    dho_policy_has(&pg->dhop_request, option))
+		return 1;
+	return 1;
+}
+
+int
+dho_policy_requested(const struct dho_policy_group *pg, const struct dhcp_opt *dho)
+{
+
+	if (dho->type & OT_NOREQ)
+		return 0;
+	if (!(dho->type & OT_REQUEST) && !dho_policy_has(&pg->dhop_request, dho->option))
+		return 0;
+	if (dho_policy_has(&pg->dhop_allow, dho->option))
+		return 1;
+	if (dho_policy_has(&pg->dhop_remove, dho->option))
+		return 0;
+	return 1;
+}
+
+static uint32_t *
+dho_policy_find(struct dho_policy *policy, uint32_t option,
+    uint32_t **free_option)
+{
+	size_t i;
+
+	for (i = 0; i < policy->dhop_policy_len; i++) {
+		if (policy->dhop_policy[i] == option)
+			return &policy->dhop_policy[i];
+		if (policy->dhop_policy[i] == 0 && *free_option == NULL)
+			*free_option = &policy->dhop_policy[i];
+	}
+
+	return 0;
+}
+
+int
+dho_policy_add(struct dho_policy *policy, uint32_t option)
+{
+	uint32_t *np, *free_option = NULL;
+
+	if (dho_policy_find(policy, option, &free_option) != NULL)
+		return 0;
+
+	if (free_option != NULL) {
+		*free_option = option;
+		return 1;
+	}
+
+	np = reallocarray(policy->dhop_policy, policy->dhop_policy_len + 1,
+	    sizeof(*policy->dhop_policy));
+	if (np == NULL)
+		return -1;
+
+	np[policy->dhop_policy_len] = option;
+	policy->dhop_policy = np;
+	policy->dhop_policy_len++;
+	return 1;
+}
+
+int
+dho_policy_del(struct dho_policy *policy, uint32_t option)
+{
+	uint32_t *o;
+
+	o = dho_policy_find(policy, option, NULL);
+	if (o == NULL)
+		return 0;
+
+	*o = 0;
+	return 1;
+}
+
+int
+dho_policy_set(const struct dho_policy_ctx *pctx, struct dho_policy *policy,
     const char *opts, int add)
 {
 	char *token, *o, *p;
 	const struct dhcp_opt *opt;
-	int match, e;
+	int match, e, err = -1;
 	unsigned int n;
 	size_t i;
 
@@ -212,51 +323,81 @@ make_option_mask(const struct dhcp_opt *dopts, size_t dopts_len,
 			token += 6;
 		if (strncmp(token, "nd_", 3) == 0)
 			token += 3;
+		n = (unsigned int)strtou(token, NULL, 0, 0, UINT_MAX, &e);
 		match = 0;
-		for (i = 0, opt = odopts; i < odopts_len; i++, opt++) {
+		for (i = 0, opt = pctx->odopts; i < pctx->odopts_len; i++, opt++) {
 			if (opt->var == NULL || opt->option == 0)
 				continue; /* buggy dhcpcd-definitions.conf */
 			if (strcmp(opt->var, token) == 0)
 				match = 1;
-			else {
-				n = (unsigned int)strtou(token, NULL, 0, 0,
-				    UINT_MAX, &e);
-				if (e == 0 && opt->option == n)
-					match = 1;
-			}
+			else if (e == 0 && opt->option == n)
+				match = 1;
 			if (match)
 				break;
 		}
 		if (match == 0) {
-			for (i = 0, opt = dopts; i < dopts_len; i++, opt++) {
+			for (i = 0, opt = pctx->dopts; i < pctx->dopts_len; i++, opt++) {
 				if (strcmp(opt->var, token) == 0)
 					match = 1;
-				else {
-					n = (unsigned int)strtou(token, NULL, 0,
-					    0, UINT_MAX, &e);
-					if (e == 0 && opt->option == n)
-						match = 1;
-				}
+				else if (e == 0 && opt->option == n)
+					match = 1;
 				if (match)
 					break;
 			}
 		}
 		if (!match || !opt->option) {
-			free(o);
 			errno = ENOENT;
-			return -1;
+			goto out;
 		}
 		if (add == 2 && !(opt->type & OT_ADDRIPV4)) {
-			free(o);
 			errno = EINVAL;
-			return -1;
+			goto out;
 		}
 		if (add == 1 || add == 2)
-			add_option_mask(mask, opt->option);
+			dho_policy_add(policy, opt->option);
 		else
-			del_option_mask(mask, opt->option);
+			dho_policy_del(policy, opt->option);
 	}
+
+	err = 0;
+
+out:
 	free(o);
+	return err;
+}
+
+/* Pass by value because we don't free the holder */
+void
+dho_policy_free(struct dho_policy policy)
+{
+	free(policy.dhop_policy);
+}
+
+void
+dho_policy_group_free(struct dho_policy_group pg)
+{
+	dho_policy_free(pg.dhop_request);
+	dho_policy_free(pg.dhop_require);
+	dho_policy_free(pg.dhop_allow);
+	dho_policy_free(pg.dhop_remove);
+	dho_policy_free(pg.dhop_reject);
+}
+
+int
+dho_policy_check(const struct dho_policy *policy,
+    int (*check)(uint32_t, void *), void *check_ctx)
+{
+	size_t i;
+	int result;
+
+	for (i = 0; i < policy->dhop_policy_len; i++) {
+		if (policy->dhop_policy[i] == 0)
+			continue;
+		result = check(policy->dhop_policy[i], check_ctx);
+		if (result != 0)
+			return result;
+	}
+
 	return 0;
 }
 

--- a/src/dhcp-common.c
+++ b/src/dhcp-common.c
@@ -232,16 +232,17 @@ dho_policy_allowed(const struct dho_policy_group *pg, uint32_t option)
 	if (dho_policy_has(&pg->dhop_allow, option) ||
 	    dho_policy_has(&pg->dhop_request, option))
 		return 1;
-	return 1;
+	return 0;
 }
 
 int
-dho_policy_requested(const struct dho_policy_group *pg, const struct dhcp_opt *dho)
+dho_policy_requested(const struct dho_policy_group *pg,
+    const struct dhcp_opt *dho)
 {
-
 	if (dho->type & OT_NOREQ)
 		return 0;
-	if (!(dho->type & OT_REQUEST) && !dho_policy_has(&pg->dhop_request, dho->option))
+	if (!(dho->type & OT_REQUEST) &&
+	    !dho_policy_has(&pg->dhop_request, dho->option))
 		return 0;
 	if (dho_policy_has(&pg->dhop_allow, dho->option))
 		return 1;
@@ -259,7 +260,8 @@ dho_policy_find(struct dho_policy *policy, uint32_t option,
 	for (i = 0; i < policy->dhop_policy_len; i++) {
 		if (policy->dhop_policy[i] == option)
 			return &policy->dhop_policy[i];
-		if (policy->dhop_policy[i] == 0 && *free_option == NULL)
+		if (policy->dhop_policy[i] == 0 && free_option != NULL &&
+		    *free_option == NULL)
 			*free_option = &policy->dhop_policy[i];
 	}
 
@@ -310,7 +312,7 @@ dho_policy_set(const struct dho_policy_ctx *pctx, struct dho_policy *policy,
 	char *token, *o, *p;
 	const struct dhcp_opt *opt;
 	int match, e, err = -1;
-	unsigned int n;
+	unsigned int n, max = UINT16_MAX;
 	size_t i;
 
 	if (opts == NULL)
@@ -321,11 +323,14 @@ dho_policy_set(const struct dho_policy_ctx *pctx, struct dho_policy *policy,
 			continue;
 		if (strncmp(token, "dhcp6_", 6) == 0)
 			token += 6;
-		if (strncmp(token, "nd_", 3) == 0)
+		else if (strncmp(token, "nd_", 3) == 0)
 			token += 3;
-		n = (unsigned int)strtou(token, NULL, 0, 0, UINT_MAX, &e);
+		else
+			max = UINT8_MAX;
+		n = (unsigned int)strtou(token, NULL, 0, 1, max, &e);
 		match = 0;
-		for (i = 0, opt = pctx->odopts; i < pctx->odopts_len; i++, opt++) {
+		for (i = 0, opt = pctx->odopts; i < pctx->odopts_len;
+		    i++, opt++) {
 			if (opt->var == NULL || opt->option == 0)
 				continue; /* buggy dhcpcd-definitions.conf */
 			if (strcmp(opt->var, token) == 0)
@@ -336,7 +341,8 @@ dho_policy_set(const struct dho_policy_ctx *pctx, struct dho_policy *policy,
 				break;
 		}
 		if (match == 0) {
-			for (i = 0, opt = pctx->dopts; i < pctx->dopts_len; i++, opt++) {
+			for (i = 0, opt = pctx->dopts; i < pctx->dopts_len;
+			    i++, opt++) {
 				if (strcmp(opt->var, token) == 0)
 					match = 1;
 				else if (e == 0 && opt->option == n)
@@ -345,18 +351,20 @@ dho_policy_set(const struct dho_policy_ctx *pctx, struct dho_policy *policy,
 					break;
 			}
 		}
-		if (!match || !opt->option) {
+		if ((!match || !opt->option) && e != 0) {
 			errno = ENOENT;
 			goto out;
 		}
-		if (add == 2 && !(opt->type & OT_ADDRIPV4)) {
+		if (match && add == 2 && !(opt->type & OT_ADDRIPV4)) {
 			errno = EINVAL;
 			goto out;
 		}
+		if (match)
+			n = opt->option;
 		if (add == 1 || add == 2)
-			dho_policy_add(policy, opt->option);
+			dho_policy_add(policy, n);
 		else
-			dho_policy_del(policy, opt->option);
+			dho_policy_del(policy, n);
 	}
 
 	err = 0;

--- a/src/dhcp-common.h
+++ b/src/dhcp-common.h
@@ -45,37 +45,37 @@
 #define NS_MAXLABEL  MAXLABEL
 #endif
 
-#define OT_REQUEST	 (1 << 0)
-#define OT_UINT8	 (1 << 1)
-#define OT_INT8		 (1 << 2)
-#define OT_UINT16	 (1 << 3)
-#define OT_INT16	 (1 << 4)
-#define OT_UINT32	 (1 << 5)
-#define OT_INT32	 (1 << 6)
-#define OT_ADDRIPV4	 (1 << 7)
-#define OT_STRING	 (1 << 8)
-#define OT_ARRAY	 (1 << 9)
-#define OT_RFC3361	 (1 << 10)
-#define OT_RFC1035	 (1 << 11)
-#define OT_RFC3442	 (1 << 12)
-#define OT_OPTIONAL	 (1 << 13)
-#define OT_ADDRIPV6	 (1 << 14)
-#define OT_BINHEX	 (1 << 15)
-#define OT_FLAG		 (1 << 16)
-#define OT_NOREQ	 (1 << 17)
-#define OT_EMBED	 (1 << 18)
-#define OT_ENCAP	 (1 << 19)
-#define OT_INDEX	 (1 << 20)
-#define OT_OPTION	 (1 << 21)
-#define OT_DOMAIN	 (1 << 22)
-#define OT_ASCII	 (1 << 23)
-#define OT_RAW		 (1 << 24)
-#define OT_ESCSTRING	 (1 << 25)
-#define OT_ESCFILE	 (1 << 26)
-#define OT_BITFLAG	 (1 << 27)
-#define OT_RESERVED	 (1 << 28)
-#define OT_URI		 (1 << 29)
-#define OT_TRUNCATED	 (1 << 30)
+#define OT_REQUEST   (1 << 0)
+#define OT_UINT8     (1 << 1)
+#define OT_INT8	     (1 << 2)
+#define OT_UINT16    (1 << 3)
+#define OT_INT16     (1 << 4)
+#define OT_UINT32    (1 << 5)
+#define OT_INT32     (1 << 6)
+#define OT_ADDRIPV4  (1 << 7)
+#define OT_STRING    (1 << 8)
+#define OT_ARRAY     (1 << 9)
+#define OT_RFC3361   (1 << 10)
+#define OT_RFC1035   (1 << 11)
+#define OT_RFC3442   (1 << 12)
+#define OT_OPTIONAL  (1 << 13)
+#define OT_ADDRIPV6  (1 << 14)
+#define OT_BINHEX    (1 << 15)
+#define OT_FLAG	     (1 << 16)
+#define OT_NOREQ     (1 << 17)
+#define OT_EMBED     (1 << 18)
+#define OT_ENCAP     (1 << 19)
+#define OT_INDEX     (1 << 20)
+#define OT_OPTION    (1 << 21)
+#define OT_DOMAIN    (1 << 22)
+#define OT_ASCII     (1 << 23)
+#define OT_RAW	     (1 << 24)
+#define OT_ESCSTRING (1 << 25)
+#define OT_ESCFILE   (1 << 26)
+#define OT_BITFLAG   (1 << 27)
+#define OT_RESERVED  (1 << 28)
+#define OT_URI	     (1 << 29)
+#define OT_TRUNCATED (1 << 30)
 
 struct dhcp_opt {
 	uint32_t option; /* Also used for IANA Enterpise Number */
@@ -99,7 +99,7 @@ struct dhcp_opt {
 struct dho_policy_ctx {
 	const struct dhcp_opt *dopts;
 	size_t dopts_len;
-    	const struct dhcp_opt *odopts;
+	const struct dhcp_opt *odopts;
 	size_t odopts_len;
 };
 
@@ -122,7 +122,8 @@ void dho_policy_group_free(struct dho_policy_group);
 int dho_policy_check(const struct dho_policy *, int (*)(uint32_t, void *),
     void *);
 
-int dho_policy_requested(const struct dho_policy_group *, const struct dhcp_opt *);
+int dho_policy_requested(const struct dho_policy_group *,
+    const struct dhcp_opt *);
 int dho_policy_removed(const struct dho_policy_group *, uint32_t);
 int dho_policy_allowed(const struct dho_policy_group *, uint32_t);
 

--- a/src/dhcp-common.h
+++ b/src/dhcp-common.h
@@ -45,45 +45,37 @@
 #define NS_MAXLABEL  MAXLABEL
 #endif
 
-#define OT_REQUEST   (1 << 0)
-#define OT_UINT8     (1 << 1)
-#define OT_INT8	     (1 << 2)
-#define OT_UINT16    (1 << 3)
-#define OT_INT16     (1 << 4)
-#define OT_UINT32    (1 << 5)
-#define OT_INT32     (1 << 6)
-#define OT_ADDRIPV4  (1 << 7)
-#define OT_STRING    (1 << 8)
-#define OT_ARRAY     (1 << 9)
-#define OT_RFC3361   (1 << 10)
-#define OT_RFC1035   (1 << 11)
-#define OT_RFC3442   (1 << 12)
-#define OT_OPTIONAL  (1 << 13)
-#define OT_ADDRIPV6  (1 << 14)
-#define OT_BINHEX    (1 << 15)
-#define OT_FLAG	     (1 << 16)
-#define OT_NOREQ     (1 << 17)
-#define OT_EMBED     (1 << 18)
-#define OT_ENCAP     (1 << 19)
-#define OT_INDEX     (1 << 20)
-#define OT_OPTION    (1 << 21)
-#define OT_DOMAIN    (1 << 22)
-#define OT_ASCII     (1 << 23)
-#define OT_RAW	     (1 << 24)
-#define OT_ESCSTRING (1 << 25)
-#define OT_ESCFILE   (1 << 26)
-#define OT_BITFLAG   (1 << 27)
-#define OT_RESERVED  (1 << 28)
-#define OT_URI	     (1 << 29)
-#define OT_TRUNCATED (1 << 30)
-
-#define DHC_REQ(r, n, o) \
-	(has_option_mask((r), (o)) && !has_option_mask((n), (o)))
-
-#define DHC_REQOPT(o, r, n)                                                  \
-	(!((o)->type & OT_NOREQ) &&                                          \
-	    ((o)->type & OT_REQUEST || has_option_mask((r), (o)->option)) && \
-	    !has_option_mask((n), (o)->option))
+#define OT_REQUEST	 (1 << 0)
+#define OT_UINT8	 (1 << 1)
+#define OT_INT8		 (1 << 2)
+#define OT_UINT16	 (1 << 3)
+#define OT_INT16	 (1 << 4)
+#define OT_UINT32	 (1 << 5)
+#define OT_INT32	 (1 << 6)
+#define OT_ADDRIPV4	 (1 << 7)
+#define OT_STRING	 (1 << 8)
+#define OT_ARRAY	 (1 << 9)
+#define OT_RFC3361	 (1 << 10)
+#define OT_RFC1035	 (1 << 11)
+#define OT_RFC3442	 (1 << 12)
+#define OT_OPTIONAL	 (1 << 13)
+#define OT_ADDRIPV6	 (1 << 14)
+#define OT_BINHEX	 (1 << 15)
+#define OT_FLAG		 (1 << 16)
+#define OT_NOREQ	 (1 << 17)
+#define OT_EMBED	 (1 << 18)
+#define OT_ENCAP	 (1 << 19)
+#define OT_INDEX	 (1 << 20)
+#define OT_OPTION	 (1 << 21)
+#define OT_DOMAIN	 (1 << 22)
+#define OT_ASCII	 (1 << 23)
+#define OT_RAW		 (1 << 24)
+#define OT_ESCSTRING	 (1 << 25)
+#define OT_ESCFILE	 (1 << 26)
+#define OT_BITFLAG	 (1 << 27)
+#define OT_RESERVED	 (1 << 28)
+#define OT_URI		 (1 << 29)
+#define OT_TRUNCATED	 (1 << 30)
 
 struct dhcp_opt {
 	uint32_t option; /* Also used for IANA Enterpise Number */
@@ -104,6 +96,13 @@ struct dhcp_opt {
 	size_t encopts_len;
 };
 
+struct dho_policy_ctx {
+	const struct dhcp_opt *dopts;
+	size_t dopts_len;
+    	const struct dhcp_opt *odopts;
+	size_t odopts_len;
+};
+
 const char *dhcp_get_hostname(struct dhcpcd_ctx *, char *, size_t,
     const struct if_options *);
 struct dhcp_opt *vivso_find(uint32_t, const void *);
@@ -111,14 +110,21 @@ struct dhcp_opt *vivso_find(uint32_t, const void *);
 ssize_t dhcp_vendor(char *, size_t);
 
 void dhcp_print_option_encoding(const struct dhcp_opt *opt, int cols);
-#define add_option_mask(var, val) \
-	((var)[(val) >> 3] = (uint8_t)((var)[(val) >> 3] | 1 << ((val) & 7)))
-#define del_option_mask(var, val) \
-	((var)[(val) >> 3] = (uint8_t)((var)[(val) >> 3] & ~(1 << ((val) & 7))))
-#define has_option_mask(var, val) \
-	((var)[(val) >> 3] & (uint8_t)(1 << ((val) & 7)))
-int make_option_mask(const struct dhcp_opt *, size_t, const struct dhcp_opt *,
-    size_t, uint8_t *, const char *, int);
+const char *dhcp_option_string(const struct dhcp_opt *, size_t, uint32_t);
+
+int dho_policy_has(const struct dho_policy *policy, uint32_t option);
+int dho_policy_add(struct dho_policy *policy, uint32_t option);
+int dho_policy_del(struct dho_policy *policy, uint32_t option);
+int dho_policy_set(const struct dho_policy_ctx *, struct dho_policy *policy,
+    const char *opts, int add);
+void dho_policy_free(struct dho_policy);
+void dho_policy_group_free(struct dho_policy_group);
+int dho_policy_check(const struct dho_policy *, int (*)(uint32_t, void *),
+    void *);
+
+int dho_policy_requested(const struct dho_policy_group *, const struct dhcp_opt *);
+int dho_policy_removed(const struct dho_policy_group *, uint32_t);
+int dho_policy_allowed(const struct dho_policy_group *, uint32_t);
 
 size_t encode_rfc1035(const char *src, uint8_t *dst);
 ssize_t decode_rfc1035(char *, size_t, const uint8_t *, size_t);

--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -669,7 +669,7 @@ dhcp_get_mtu(const struct interface *ifp)
 		return (uint16_t)ifo->mtu;
 	mtu = 0; /* bogus gcc warning */
 	if ((state = D_CSTATE(ifp)) == NULL ||
-	    dho_policy_allowed(pg, DHO_MTU) ||
+	    !dho_policy_allowed(pg, DHO_MTU) ||
 	    get_option_uint16(ifp->ctx, &mtu, state->new, state->new_len,
 		DHO_MTU) == -1)
 		return 0;
@@ -999,8 +999,7 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 		}
 		*n_params = (uint8_t)(p - n_params - 1);
 
-		if (mtu != -1 &&
-		    (dho_policy_allowed(pg, DHO_MAXMESSAGESIZE))) {
+		if (mtu != -1 && (dho_policy_allowed(pg, DHO_MAXMESSAGESIZE))) {
 			AREA_CHECK(2);
 			*p++ = DHO_MAXMESSAGESIZE;
 			*p++ = 2;
@@ -1026,8 +1025,7 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 		p += state->clientid[0] + 1;
 	}
 
-	if (DHCP_DIR(type) &&
-	    dho_policy_allowed(pg, DHO_VENDORCLASSID) &&
+	if (DHCP_DIR(type) && dho_policy_allowed(pg, DHO_VENDORCLASSID) &&
 	    ifo->vendorclassid[0]) {
 		AREA_CHECK(ifo->vendorclassid[0]);
 		*p++ = DHO_VENDORCLASSID;
@@ -1134,8 +1132,7 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 		}
 
 #ifndef SMALL
-		if (ifo->vivco_len &&
-		    dho_policy_allowed(pg, DHO_VIVCO)) {
+		if (ifo->vivco_len && dho_policy_allowed(pg, DHO_VIVCO)) {
 			struct vivco *vivco = ifo->vivco;
 			size_t vlen = ifo->vivco_len;
 			struct rfc3396_ctx rctx = {
@@ -1161,8 +1158,7 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 			}
 		}
 
-		if (ifo->vsio_len &&
-		    dho_policy_allowed(pg, DHO_VIVSO)) {
+		if (ifo->vsio_len && dho_policy_allowed(pg, DHO_VIVSO)) {
 			struct vsio *vso = ifo->vsio;
 			size_t vlen = ifo->vsio_len;
 			struct vsio_so *so;

--- a/src/dhcp.c
+++ b/src/dhcp.c
@@ -557,6 +557,7 @@ get_option_routes(rb_tree_t *routes, struct interface *ifp,
     const struct bootp *bootp, size_t bootp_len)
 {
 	struct if_options *ifo = ifp->options;
+	struct dho_policy_group *pg = &ifo->dhopg_dhcp;
 	const uint8_t *p;
 	const uint8_t *e;
 	struct rt *rt = NULL;
@@ -566,12 +567,12 @@ get_option_routes(rb_tree_t *routes, struct interface *ifp,
 	int n;
 
 	/* If we have CSR's then we MUST use these only */
-	if (!has_option_mask(ifo->nomask, DHO_CSR))
+	if (dho_policy_allowed(pg, DHO_CSR))
 		p = get_option(ifp->ctx, bootp, bootp_len, DHO_CSR, &len);
 	else
 		p = NULL;
 	/* Check for crappy MS option */
-	if (!p && !has_option_mask(ifo->nomask, DHO_MSCSR)) {
+	if (!p && dho_policy_allowed(pg, DHO_MSCSR)) {
 		p = get_option(ifp->ctx, bootp, bootp_len, DHO_MSCSR, &len);
 		if (p)
 			csr = "MS ";
@@ -591,7 +592,7 @@ get_option_routes(rb_tree_t *routes, struct interface *ifp,
 
 	n = 0;
 	/* OK, get our static routes first. */
-	if (!has_option_mask(ifo->nomask, DHO_STATICROUTE))
+	if (dho_policy_allowed(pg, DHO_STATICROUTE))
 		p = get_option(ifp->ctx, bootp, bootp_len, DHO_STATICROUTE,
 		    &len);
 	else
@@ -632,7 +633,7 @@ get_option_routes(rb_tree_t *routes, struct interface *ifp,
 	}
 
 	/* Now grab our routers */
-	if (!has_option_mask(ifo->nomask, DHO_ROUTER))
+	if (dho_policy_allowed(pg, DHO_ROUTER))
 		p = get_option(ifp->ctx, bootp, bootp_len, DHO_ROUTER, &len);
 	else
 		p = NULL;
@@ -660,13 +661,15 @@ uint16_t
 dhcp_get_mtu(const struct interface *ifp)
 {
 	const struct dhcp_state *state;
+	const struct if_options *ifo = ifp->options;
+	const struct dho_policy_group *pg = &ifo->dhopg_dhcp;
 	uint16_t mtu;
 
-	if (ifp->options->mtu)
-		return (uint16_t)ifp->options->mtu;
+	if (ifo->mtu)
+		return (uint16_t)ifo->mtu;
 	mtu = 0; /* bogus gcc warning */
 	if ((state = D_CSTATE(ifp)) == NULL ||
-	    has_option_mask(ifp->options->nomask, DHO_MTU) ||
+	    dho_policy_allowed(pg, DHO_MTU) ||
 	    get_option_uint16(ifp->ctx, &mtu, state->new, state->new_len,
 		DHO_MTU) == -1)
 		return 0;
@@ -797,6 +800,7 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 	size_t len, i;
 	const struct dhcp_opt *opt;
 	struct if_options *ifo = ifp->options;
+	const struct dho_policy_group *pg = &ifo->dhopg_dhcp;
 	const struct dhcp_state *state = D_CSTATE(ifp);
 	const struct dhcp_lease *lease = &state->lease;
 	char hbuf[HOSTNAME_MAX_LEN + 1];
@@ -967,11 +971,11 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 		*p++ = 0;
 		for (i = 0, opt = ctx->dhcp_opts; i < ctx->dhcp_opts_len;
 		    i++, opt++) {
-			if (!DHC_REQOPT(opt, ifo->requestmask, ifo->nomask))
-				continue;
 			if (type == DHCP_INFORM &&
 			    (opt->option == DHO_RENEWALTIME ||
 				opt->option == DHO_REBINDTIME))
+				continue;
+			if (!dho_policy_requested(pg, opt))
 				continue;
 			AREA_FIT(1);
 			*p++ = (uint8_t)opt->option;
@@ -984,11 +988,11 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 					break;
 			if (lp < p)
 				continue;
-			if (!DHC_REQOPT(opt, ifo->requestmask, ifo->nomask))
-				continue;
 			if (type == DHCP_INFORM &&
 			    (opt->option == DHO_RENEWALTIME ||
 				opt->option == DHO_REBINDTIME))
+				continue;
+			if (!dho_policy_requested(pg, opt))
 				continue;
 			AREA_FIT(1);
 			*p++ = (uint8_t)opt->option;
@@ -996,7 +1000,7 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 		*n_params = (uint8_t)(p - n_params - 1);
 
 		if (mtu != -1 &&
-		    !(has_option_mask(ifo->nomask, DHO_MAXMESSAGESIZE))) {
+		    (dho_policy_allowed(pg, DHO_MAXMESSAGESIZE))) {
 			AREA_CHECK(2);
 			*p++ = DHO_MAXMESSAGESIZE;
 			*p++ = 2;
@@ -1006,7 +1010,7 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 		}
 
 		if (ifo->userclass[0] &&
-		    !has_option_mask(ifo->nomask, DHO_USERCLASS)) {
+		    dho_policy_allowed(pg, DHO_USERCLASS)) {
 			AREA_CHECK(ifo->userclass[0]);
 			*p++ = DHO_USERCLASS;
 			memcpy(p, ifo->userclass,
@@ -1023,7 +1027,7 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 	}
 
 	if (DHCP_DIR(type) &&
-	    !has_option_mask(ifo->nomask, DHO_VENDORCLASSID) &&
+	    dho_policy_allowed(pg, DHO_VENDORCLASSID) &&
 	    ifo->vendorclassid[0]) {
 		AREA_CHECK(ifo->vendorclassid[0]);
 		*p++ = DHO_VENDORCLASSID;
@@ -1033,7 +1037,7 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 	}
 
 	if (type == DHCP_DISCOVER && !(ctx->options & DHCPCD_TEST) &&
-	    DHC_REQ(ifo->requestmask, ifo->nomask, DHO_RAPIDCOMMIT)) {
+	    dho_policy_allowed(pg, DHO_RAPIDCOMMIT)) {
 		/* RFC 4039 Section 3 */
 		AREA_CHECK(0);
 		*p++ = DHO_RAPIDCOMMIT;
@@ -1114,7 +1118,7 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 
 	/* RFC 2563 Auto Configure */
 	if (type == DHCP_DISCOVER && ifo->options & DHCPCD_IPV4LL &&
-	    !(has_option_mask(ifo->nomask, DHO_AUTOCONFIGURE))) {
+	    dho_policy_allowed(pg, DHO_AUTOCONFIGURE)) {
 		AREA_CHECK(1);
 		*p++ = DHO_AUTOCONFIGURE;
 		*p++ = 1;
@@ -1131,7 +1135,7 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 
 #ifndef SMALL
 		if (ifo->vivco_len &&
-		    !has_option_mask(ifo->nomask, DHO_VIVCO)) {
+		    dho_policy_allowed(pg, DHO_VIVCO)) {
 			struct vivco *vivco = ifo->vivco;
 			size_t vlen = ifo->vivco_len;
 			struct rfc3396_ctx rctx = {
@@ -1157,7 +1161,8 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 			}
 		}
 
-		if (ifo->vsio_len && !has_option_mask(ifo->nomask, DHO_VIVSO)) {
+		if (ifo->vsio_len &&
+		    dho_policy_allowed(pg, DHO_VIVSO)) {
 			struct vsio *vso = ifo->vsio;
 			size_t vlen = ifo->vsio_len;
 			struct vsio_so *so;
@@ -1201,7 +1206,7 @@ make_message(struct bootp **bootpm, const struct interface *ifp, uint8_t type)
 #ifdef AUTH
 		if ((ifo->auth.options & DHCPCD_AUTH_SENDREQUIRE) !=
 			DHCPCD_AUTH_SENDREQUIRE &&
-		    !has_option_mask(ifo->nomask, DHO_FORCERENEW_NONCE)) {
+		    dho_policy_allowed(pg, DHO_FORCERENEW_NONCE)) {
 			/* We support HMAC-MD5 */
 			AREA_CHECK(1);
 			*p++ = DHO_FORCERENEW_NONCE;
@@ -1362,6 +1367,7 @@ dhcp_env(FILE *fenv, const char *prefix, const struct interface *ifp,
     const struct bootp *bootp, size_t bootp_len)
 {
 	const struct if_options *ifo;
+	const struct dho_policy_group *pg;
 	const uint8_t *p;
 	struct in_addr addr;
 	struct in_addr net;
@@ -1373,6 +1379,8 @@ dhcp_env(FILE *fenv, const char *prefix, const struct interface *ifp,
 	uint32_t en;
 
 	ifo = ifp->options;
+	pg = &ifo->dhopg_dhcp;
+
 	if (get_option_uint8(ifp->ctx, &overl, bootp, bootp_len,
 		DHO_OPTSOVERLOADED) == -1)
 		overl = 0;
@@ -1432,7 +1440,7 @@ dhcp_env(FILE *fenv, const char *prefix, const struct interface *ifp,
 
 	for (i = 0, opt = ifp->ctx->dhcp_opts; i < ifp->ctx->dhcp_opts_len;
 	    i++, opt++) {
-		if (has_option_mask(ifo->nomask, opt->option))
+		if (dho_policy_has(&pg->dhop_remove, opt->option))
 			continue;
 		if (dhcp_getoverride(ifo, opt->option))
 			continue;
@@ -1458,7 +1466,7 @@ dhcp_env(FILE *fenv, const char *prefix, const struct interface *ifp,
 
 	for (i = 0, opt = ifo->dhcp_override; i < ifo->dhcp_override_len;
 	    i++, opt++) {
-		if (has_option_mask(ifo->nomask, opt->option))
+		if (dho_policy_has(&pg->dhop_remove, opt->option))
 			continue;
 		p = get_option(ifp->ctx, bootp, bootp_len, opt->option, &pl);
 		if (p == NULL)
@@ -3036,12 +3044,52 @@ dhcp_redirect_dhcp(struct interface *ifp, struct bootp *bootp, size_t bootp_len,
 	}
 }
 
+struct dhcp_policy {
+	struct dhcpcd_ctx *ctx;
+	struct bootp *bootp;
+	size_t bootp_len;
+	uint8_t type;
+};
+
+static int
+dhcp_policy_reject(uint32_t option, void *arg)
+{
+	struct dhcp_policy *dp = arg;
+
+	if (get_option(dp->ctx, dp->bootp, dp->bootp_len, (uint8_t)option,
+		NULL))
+		return 1;
+
+	return 0;
+}
+
+static int
+dhcp_policy_require(uint32_t option, void *arg)
+{
+	struct dhcp_policy *dp = arg;
+
+	if (get_option(dp->ctx, dp->bootp, dp->bootp_len, (uint8_t)option,
+		NULL))
+		return 0;
+
+	/* If we are BOOTP, then ignore the need for serverid.
+	 * To ignore BOOTP, require dhcp_message_type.
+	 * However, nothing really stops BOOTP from providing
+	 * DHCP style options as well so the above isn't
+	 * always true. */
+	if (dp->type == 0 && option == DHO_SERVERID)
+		return 0;
+
+	return -1;
+}
+
 static void
 dhcp_handledhcp(struct interface *ifp, struct bootp *bootp, size_t bootp_len,
     const struct in_addr *from)
 {
 	struct dhcp_state *state = D_STATE(ifp);
 	struct if_options *ifo = ifp->options;
+	struct dho_policy_group *pg = &ifo->dhopg_dhcp;
 	struct dhcp_lease *lease = &state->lease;
 	uint8_t type;
 	struct in_addr addr;
@@ -3050,6 +3098,12 @@ dhcp_handledhcp(struct interface *ifp, struct bootp *bootp, size_t bootp_len,
 	bool bootp_copied;
 	uint32_t v6only_time = 0;
 	bool use_v6only = false, has_auto_conf = false;
+	struct dhcp_policy dp = {
+		.ctx = ifp->ctx,
+		.bootp = bootp,
+		.bootp_len = bootp_len,
+	};
+
 #ifdef AUTH
 	const uint8_t *auth;
 	size_t auth_len;
@@ -3205,17 +3259,14 @@ dhcp_handledhcp(struct interface *ifp, struct bootp *bootp, size_t bootp_len,
 	state->interval = 0;
 
 	/* Ensure that no reject options are present */
-	for (i = 1; i < 255; i++) {
-		if (has_option_mask(ifo->rejectmask, i) &&
-		    get_option(ifp->ctx, bootp, bootp_len, (uint8_t)i, NULL)) {
-			LOGDHCP(LOG_WARNING, "reject DHCP");
-			return;
-		}
+	if (dho_policy_check(&pg->dhop_reject, dhcp_policy_reject, &dp) == 1) {
+		LOGDHCP(LOG_WARNING, "reject DHCP");
+		return;
 	}
 
 	if (type == DHCP_NAK) {
 		/* For NAK, only check if we require the ServerID */
-		if (has_option_mask(ifo->requiremask, DHO_SERVERID) &&
+		if (dho_policy_has(&pg->dhop_require, DHO_SERVERID) &&
 		    get_option_addr(ifp->ctx, &addr, bootp, bootp_len,
 			DHO_SERVERID) == -1) {
 			LOGDHCP(LOG_WARNING, "reject NAK");
@@ -3245,22 +3296,14 @@ dhcp_handledhcp(struct interface *ifp, struct bootp *bootp, size_t bootp_len,
 	}
 
 	/* Ensure that all required options are present */
-	for (i = 1; i < 255; i++) {
-		if (has_option_mask(ifo->requiremask, i) &&
-		    !get_option(ifp->ctx, bootp, bootp_len, (uint8_t)i, NULL)) {
-			/* If we are BOOTP, then ignore the need for serverid.
-			 * To ignore BOOTP, require dhcp_message_type.
-			 * However, nothing really stops BOOTP from providing
-			 * DHCP style options as well so the above isn't
-			 * always true. */
-			if (type == 0 && i == DHO_SERVERID)
-				continue;
-			LOGDHCP(LOG_WARNING, "reject DHCP");
-			return;
-		}
+	dp.type = type;
+	if (dho_policy_check(&pg->dhop_require, dhcp_policy_require, &dp) ==
+	    -1) {
+		LOGDHCP(LOG_WARNING, "reject DHCP");
+		return;
 	}
 
-	if (has_option_mask(ifo->requestmask, DHO_IPV6_PREFERRED_ONLY)) {
+	if (dho_policy_allowed(pg, DHO_IPV6_PREFERRED_ONLY)) {
 		if (get_option_uint32(ifp->ctx, &v6only_time, bootp, bootp_len,
 			DHO_IPV6_PREFERRED_ONLY) == 0 &&
 		    (state->state == DHS_DISCOVER ||
@@ -3366,7 +3409,7 @@ dhcp_handledhcp(struct interface *ifp, struct bootp *bootp, size_t bootp_len,
 
 		/* Test for rapid commit in the OFFER */
 		if (!(ifp->ctx->options & DHCPCD_TEST) &&
-		    has_option_mask(ifo->requestmask, DHO_RAPIDCOMMIT) &&
+		    dho_policy_allowed(pg, DHO_RAPIDCOMMIT) &&
 		    get_option(ifp->ctx, bootp, bootp_len, DHO_RAPIDCOMMIT,
 			NULL)) {
 			state->state = DHS_REQUEST;
@@ -3428,7 +3471,7 @@ dhcp_handledhcp(struct interface *ifp, struct bootp *bootp, size_t bootp_len,
 
 		if (state->state == DHS_DISCOVER) {
 			/* We only allow ACK of rapid commit DISCOVER. */
-			if (has_option_mask(ifo->requestmask,
+			if (dho_policy_has(&pg->dhop_request,
 				DHO_RAPIDCOMMIT) &&
 			    get_option(ifp->ctx, bootp, bootp_len,
 				DHO_RAPIDCOMMIT, NULL))
@@ -4344,7 +4387,8 @@ dhcp_handleifa(int cmd, struct ipv4_addr *ia, pid_t pid)
 
 	if (ifp->flags & IFF_POINTOPOINT) {
 		for (i = 1; i < 255; i++)
-			if (i != DHO_ROUTER && has_option_mask(ifo->dstmask, i))
+			if (i != DHO_ROUTER &&
+			    dho_policy_has(&ifo->dhop_destination, i))
 				dhcp_message_add_addr(state->new, i, ia->brd);
 	}
 

--- a/src/dhcp6.c
+++ b/src/dhcp6.c
@@ -4056,7 +4056,7 @@ dhcp6_start1(void *arg)
 		int err;
 
 		for (dhc = dhcp_compats; dhc->dhcp_opt; dhc++) {
-			if (!dho_policy_allowed(dpg, dhc->dhcp_opt))
+			if (!dho_policy_has(&dpg->dhop_request, dhc->dhcp_opt))
 				continue;
 			err = dho_policy_add(&pg->dhop_request, dhc->dhcp6_opt);
 			if (err == -1) {

--- a/src/dhcp6.c
+++ b/src/dhcp6.c
@@ -821,14 +821,13 @@ dhcp6_makemessage(struct interface *ifp)
 			len += sizeof(o) + 1 + hl;
 		}
 
-		if (dho_policy_allowed(pg, D6_OPTION_MUDURL) &&
-		    ifo->mudurl[0])
+		if (dho_policy_allowed(pg, D6_OPTION_MUDURL) && ifo->mudurl[0])
 			len += sizeof(o) + ifo->mudurl[0];
 
 #ifdef AUTH
 		if ((ifo->auth.options & DHCPCD_AUTH_SENDREQUIRE) !=
 			DHCPCD_AUTH_SENDREQUIRE &&
-			dho_policy_allowed(pg, D6_OPTION_RECONF_ACCEPT))
+		    dho_policy_allowed(pg, D6_OPTION_RECONF_ACCEPT))
 			len += sizeof(o); /* Reconfigure Accept */
 #endif
 	}
@@ -921,7 +920,7 @@ dhcp6_makemessage(struct interface *ifp)
 	}
 
 	if (state->state == DH6S_DISCOVER && !(ctx->options & DHCPCD_TEST) &&
-		dho_policy_allowed(pg, D6_OPTION_RAPID_COMMIT))
+	    dho_policy_allowed(pg, D6_OPTION_RAPID_COMMIT))
 		len += sizeof(o);
 
 	if (m == NULL) {
@@ -1199,8 +1198,7 @@ dhcp6_makemessage(struct interface *ifp)
 			memcpy(o_lenp, &o.len, sizeof(o.len));
 		}
 
-		if (dho_policy_allowed(pg, D6_OPTION_MUDURL) &&
-		    ifo->mudurl[0])
+		if (dho_policy_allowed(pg, D6_OPTION_MUDURL) && ifo->mudurl[0])
 			COPYIN(D6_OPTION_MUDURL, ifo->mudurl + 1,
 			    ifo->mudurl[0]);
 
@@ -4057,8 +4055,7 @@ dhcp6_start1(void *arg)
 		const struct dho_policy_group *dpg = &ifo->dhopg_dhcp;
 
 		for (dhc = dhcp_compats; dhc->dhcp_opt; dhc++) {
-			if (dho_policy_allowed(dpg, dhc->dhcp_opt) &&
-			    dho_policy_has(&pg->dhop_request, dhc->dhcp_opt))
+			if (dho_policy_allowed(dpg, dhc->dhcp_opt))
 				dho_policy_add(&pg->dhop_request,
 				    dhc->dhcp6_opt);
 		}

--- a/src/dhcp6.c
+++ b/src/dhcp6.c
@@ -4053,14 +4053,25 @@ dhcp6_start1(void *arg)
 	   match configured DHCPv4 options to DHCPv6 equivalents. */
 	if (pg->dhop_request.dhop_policy_len == 0) {
 		const struct dho_policy_group *dpg = &ifo->dhopg_dhcp;
+		int err;
 
 		for (dhc = dhcp_compats; dhc->dhcp_opt; dhc++) {
-			if (dho_policy_allowed(dpg, dhc->dhcp_opt))
-				dho_policy_add(&pg->dhop_request,
-				    dhc->dhcp6_opt);
+			if (!dho_policy_allowed(dpg, dhc->dhcp_opt))
+				continue;
+			err = dho_policy_add(&pg->dhop_request, dhc->dhcp6_opt);
+			if (err == -1) {
+				logerr(__func__);
+				return;
+			}
 		}
-		if (ifo->fqdn != FQDN_DISABLE || ifo->options & DHCPCD_HOSTNAME)
-			dho_policy_add(&pg->dhop_request, D6_OPTION_FQDN);
+		if (ifo->fqdn != FQDN_DISABLE ||
+		    ifo->options & DHCPCD_HOSTNAME) {
+			err = dho_policy_add(&pg->dhop_request, D6_OPTION_FQDN);
+			if (err == -1) {
+				logerr(__func__);
+				return;
+			}
+		}
 	}
 
 #ifndef SMALL

--- a/src/dhcp6.c
+++ b/src/dhcp6.c
@@ -703,6 +703,7 @@ dhcp6_makemessage(struct interface *ifp)
 	uint16_t si_len, uni_len, n_options;
 	uint8_t *o_lenp;
 	struct if_options *ifo = ifp->options;
+	const struct dho_policy_group *pg = &ifo->dhopg_dhcp6;
 	const struct dhcp_opt *opt, *opt2;
 	const struct ipv6_addr *ap;
 	char hbuf[HOSTNAME_MAX_LEN + 1];
@@ -794,7 +795,7 @@ dhcp6_makemessage(struct interface *ifp)
 			}
 			if (n < ifo->dhcp6_override_len)
 				continue;
-			if (!DHC_REQOPT(opt, ifo->requestmask6, ifo->nomask6))
+			if (!dho_policy_requested(pg, opt))
 				continue;
 			n_options++;
 			len += sizeof(o.len);
@@ -802,7 +803,7 @@ dhcp6_makemessage(struct interface *ifp)
 #ifndef SMALL
 		for (l = 0, opt = ifo->dhcp6_override;
 		    l < ifo->dhcp6_override_len; l++, opt++) {
-			if (!DHC_REQOPT(opt, ifo->requestmask6, ifo->nomask6))
+			if (!dho_policy_requested(pg, opt))
 				continue;
 			n_options++;
 			len += sizeof(o.len);
@@ -820,15 +821,14 @@ dhcp6_makemessage(struct interface *ifp)
 			len += sizeof(o) + 1 + hl;
 		}
 
-		if (!has_option_mask(ifo->nomask6, D6_OPTION_MUDURL) &&
+		if (dho_policy_allowed(pg, D6_OPTION_MUDURL) &&
 		    ifo->mudurl[0])
 			len += sizeof(o) + ifo->mudurl[0];
 
 #ifdef AUTH
 		if ((ifo->auth.options & DHCPCD_AUTH_SENDREQUIRE) !=
 			DHCPCD_AUTH_SENDREQUIRE &&
-		    DHC_REQ(ifo->requestmask6, ifo->nomask6,
-			D6_OPTION_RECONF_ACCEPT))
+			dho_policy_allowed(pg, D6_OPTION_RECONF_ACCEPT))
 			len += sizeof(o); /* Reconfigure Accept */
 #endif
 	}
@@ -843,13 +843,13 @@ dhcp6_makemessage(struct interface *ifp)
 		len += sizeof(o) + ctx->duid_len;
 	}
 
-	if (!has_option_mask(ifo->nomask6, D6_OPTION_USER_CLASS))
+	if (dho_policy_allowed(pg, D6_OPTION_USER_CLASS))
 		len += dhcp6_makeuser(NULL, ifp);
 
 #ifndef SMALL
-	if (!has_option_mask(ifo->nomask6, D6_OPTION_VENDOR_CLASS))
+	if (dho_policy_allowed(pg, D6_OPTION_VENDOR_CLASS))
 		len += dhcp6_makevendor(NULL, ifp);
-	if (!has_option_mask(ifo->nomask6, D6_OPTION_VENDOR_OPTS))
+	if (dho_policy_allowed(pg, D6_OPTION_VENDOR_OPTS))
 		len += dhcp6_makevendoropts(NULL, ifp);
 #endif
 
@@ -921,7 +921,7 @@ dhcp6_makemessage(struct interface *ifp)
 	}
 
 	if (state->state == DH6S_DISCOVER && !(ctx->options & DHCPCD_TEST) &&
-	    DHC_REQ(ifo->requestmask6, ifo->nomask6, D6_OPTION_RAPID_COMMIT))
+		dho_policy_allowed(pg, D6_OPTION_RAPID_COMMIT))
 		len += sizeof(o);
 
 	if (m == NULL) {
@@ -933,7 +933,7 @@ dhcp6_makemessage(struct interface *ifp)
 	case DH6S_REQUEST: /* FALLTHROUGH */
 	case DH6S_RENEW:   /* FALLTHROUGH */
 	case DH6S_RELEASE:
-		if (has_option_mask(ifo->nomask6, D6_OPTION_UNICAST)) {
+		if (!dho_policy_allowed(pg, D6_OPTION_UNICAST)) {
 			unicast = NULL;
 			break;
 		}
@@ -1127,7 +1127,7 @@ dhcp6_makemessage(struct interface *ifp)
 			if (n < ifo->dhcp6_override_len)
 				continue;
 #endif
-			if (!DHC_REQOPT(opt, ifo->requestmask6, ifo->nomask6))
+			if (!dho_policy_requested(pg, opt))
 				continue;
 			o.code = htons((uint16_t)opt->option);
 			memcpy(p, &o.code, sizeof(o.code));
@@ -1137,7 +1137,7 @@ dhcp6_makemessage(struct interface *ifp)
 #ifndef SMALL
 		for (l = 0, opt = ifo->dhcp6_override;
 		    l < ifo->dhcp6_override_len; l++, opt++) {
-			if (!DHC_REQOPT(opt, ifo->requestmask6, ifo->nomask6))
+			if (!dho_policy_requested(pg, opt))
 				continue;
 			o.code = htons((uint16_t)opt->option);
 			memcpy(p, &o.code, sizeof(o.code));
@@ -1159,16 +1159,16 @@ dhcp6_makemessage(struct interface *ifp)
 	COPYIN(D6_OPTION_ELAPSED, &si_len, sizeof(si_len));
 
 	if (state->state == DH6S_DISCOVER && !(ctx->options & DHCPCD_TEST) &&
-	    DHC_REQ(ifo->requestmask6, ifo->nomask6, D6_OPTION_RAPID_COMMIT))
+	    dho_policy_allowed(pg, D6_OPTION_RAPID_COMMIT))
 		COPYIN1(D6_OPTION_RAPID_COMMIT, 0);
 
-	if (!has_option_mask(ifo->nomask6, D6_OPTION_USER_CLASS))
+	if (dho_policy_allowed(pg, D6_OPTION_USER_CLASS))
 		p += dhcp6_makeuser(p, ifp);
 
 #ifndef SMALL
-	if (!has_option_mask(ifo->nomask6, D6_OPTION_VENDOR_CLASS))
+	if (dho_policy_allowed(pg, D6_OPTION_VENDOR_CLASS))
 		p += dhcp6_makevendor(p, ifp);
-	if (!has_option_mask(ifo->nomask6, D6_OPTION_VENDOR_OPTS))
+	if (dho_policy_allowed(pg, D6_OPTION_VENDOR_OPTS))
 		p += dhcp6_makevendoropts(p, ifp);
 #endif
 
@@ -1199,7 +1199,7 @@ dhcp6_makemessage(struct interface *ifp)
 			memcpy(o_lenp, &o.len, sizeof(o.len));
 		}
 
-		if (!has_option_mask(ifo->nomask6, D6_OPTION_MUDURL) &&
+		if (dho_policy_allowed(pg, D6_OPTION_MUDURL) &&
 		    ifo->mudurl[0])
 			COPYIN(D6_OPTION_MUDURL, ifo->mudurl + 1,
 			    ifo->mudurl[0]);
@@ -1207,8 +1207,7 @@ dhcp6_makemessage(struct interface *ifp)
 #ifdef AUTH
 		if ((ifo->auth.options & DHCPCD_AUTH_SENDREQUIRE) !=
 			DHCPCD_AUTH_SENDREQUIRE &&
-		    DHC_REQ(ifo->requestmask6, ifo->nomask6,
-			D6_OPTION_RECONF_ACCEPT))
+		    dho_policy_allowed(pg, D6_OPTION_RECONF_ACCEPT))
 			COPYIN1(D6_OPTION_RECONF_ACCEPT, 0);
 #endif
 	}
@@ -1695,6 +1694,7 @@ dhcp6_startdiscover(void *arg)
 {
 	struct interface *ifp;
 	struct if_options *ifo;
+	struct dho_policy_group *pg;
 	struct dhcp6_state *state;
 	int llevel;
 	struct ipv6_addr *ia;
@@ -1702,13 +1702,14 @@ dhcp6_startdiscover(void *arg)
 	ifp = arg;
 	state = D6_STATE(ifp);
 	ifo = ifp->options;
+	pg = &ifo->dhopg_dhcp6;
 #ifndef SMALL
 	if (state->reason == NULL || strcmp(state->reason, "TIMEOUT6") != 0)
 		dhcp6_delete_delegates(ifp);
 #endif
 	/* Ensure we never request INFO_REFRESH_TIME,
 	 * this only belongs in Information-Request messages */
-	del_option_mask(ifo->requestmask6, D6_OPTION_INFO_REFRESH_TIME);
+	dho_policy_del(&pg->dhop_request, D6_OPTION_INFO_REFRESH_TIME);
 
 	if (state->new == NULL && !state->failed)
 		llevel = LOG_INFO;
@@ -1743,6 +1744,7 @@ dhcp6_startinform(void *arg)
 	struct dhcp6_state *state;
 	int llevel;
 	struct if_options *ifo;
+	struct dho_policy_group *pg;
 
 	ifp = arg;
 	state = D6_STATE(ifp);
@@ -1757,7 +1759,8 @@ dhcp6_startinform(void *arg)
 	state->MRC = 0;
 
 	/* Ensure we always request INFO_REFRESH_TIME as per rfc8415 */
-	add_option_mask(ifo->requestmask6, D6_OPTION_INFO_REFRESH_TIME);
+	pg = &ifo->dhopg_dhcp6;
+	dho_policy_add(&pg->dhop_request, D6_OPTION_INFO_REFRESH_TIME);
 
 	if (dhcp6_makemessage(ifp) == -1) {
 		logerr("%s: %s", __func__, ifp->name);
@@ -3405,25 +3408,62 @@ dhcp6_adjust_max_rt(struct interface *ifp, struct dhcp6_message *r, size_t len)
 	}
 }
 
+struct dhcp6_policy {
+	const struct dhcpcd_ctx *ctx;
+	const char *ifname;
+	const char *sfrom;
+	struct dhcp6_message *msg;
+	size_t len;
+};
+
+static int
+dhcp6_require(uint32_t option, void *arg)
+{
+	struct dhcp6_policy *ctx = arg;
+	void *o;
+
+	o = dhcp6_findmoption(ctx->msg, ctx->len, (uint16_t)option, NULL);
+	if (o != NULL)
+		return 0;
+
+	logwarnx("%s: reject DHCPv6 (missing option %u) from %s", ctx->ifname,
+	    option, ctx->sfrom);
+	return -1;
+}
+
+static int
+dhcp6_reject(uint32_t option, void *arg)
+{
+	struct dhcp6_policy *ctx = arg;
+	void *o;
+
+	o = dhcp6_findmoption(ctx->msg, ctx->len, (uint16_t)option, NULL);
+	if (o == NULL)
+		return 0;
+
+	logwarnx("%s: reject DHCPv6 (option %u) from %s", ctx->ifname, option,
+	    ctx->sfrom);
+	return -1;
+}
+
 static void
 dhcp6_recvif(struct interface *ifp, const char *sfrom, struct dhcp6_message *r,
     size_t len)
 {
-	struct dhcpcd_ctx *ctx;
-	size_t i;
 	const char *op;
 	struct dhcp6_state *state;
+	struct dhcp6_policy policy = { .sfrom = sfrom, .msg = r, .len = len };
+	int err;
 	uint8_t *o, preference = 0;
 	uint16_t ol;
-	const struct dhcp_opt *opt;
 	const struct if_options *ifo;
+	const struct dho_policy_group *pg;
 	bool valid_op;
 #ifdef AUTH
 	uint8_t *auth;
 	uint16_t auth_len;
 #endif
 
-	ctx = ifp->ctx;
 	state = D6_STATE(ifp);
 	if (state == NULL || state->send == NULL) {
 		logdebugx("%s: DHCPv6 reply received but not running",
@@ -3446,21 +3486,16 @@ dhcp6_recvif(struct interface *ifp, const char *sfrom, struct dhcp6_message *r,
 	}
 
 	ifo = ifp->options;
-	for (i = 0, opt = ctx->dhcp6_opts; i < ctx->dhcp6_opts_len;
-	    i++, opt++) {
-		if (has_option_mask(ifo->requiremask6, opt->option) &&
-		    !dhcp6_findmoption(r, len, (uint16_t)opt->option, NULL)) {
-			logwarnx("%s: reject DHCPv6 (no option %s) from %s",
-			    ifp->name, opt->var, sfrom);
-			return;
-		}
-		if (has_option_mask(ifo->rejectmask6, opt->option) &&
-		    dhcp6_findmoption(r, len, (uint16_t)opt->option, NULL)) {
-			logwarnx("%s: reject DHCPv6 (option %s) from %s",
-			    ifp->name, opt->var, sfrom);
-			return;
-		}
-	}
+	pg = &ifo->dhopg_dhcp6;
+	policy.ifname = ifp->name;
+
+	err = dho_policy_check(&pg->dhop_require, dhcp6_require, &policy);
+	if (err == -1)
+		return;
+
+	err = dho_policy_check(&pg->dhop_reject, dhcp6_reject, &policy);
+	if (err == -1)
+		return;
 
 #ifdef AUTH
 	/* Authenticate the message */
@@ -3506,8 +3541,7 @@ dhcp6_recvif(struct interface *ifp, const char *sfrom, struct dhcp6_message *r,
 		case DH6S_DISCOVER:
 			/* Only accept REPLY in DISCOVER for RAPID_COMMIT.
 			 * Normally we get an ADVERTISE for a DISCOVER. */
-			if (!has_option_mask(ifo->requestmask6,
-				D6_OPTION_RAPID_COMMIT) ||
+			if (!dho_policy_allowed(pg, D6_OPTION_RAPID_COMMIT) ||
 			    !dhcp6_findmoption(r, len, D6_OPTION_RAPID_COMMIT,
 				NULL)) {
 				valid_op = false;
@@ -3991,8 +4025,8 @@ dhcp6_start1(void *arg)
 	struct interface *ifp = arg;
 	struct dhcpcd_ctx *ctx = ifp->ctx;
 	struct if_options *ifo = ifp->options;
+	struct dho_policy_group *pg = &ifo->dhopg_dhcp6;
 	struct dhcp6_state *state;
-	size_t i;
 	const struct dhcp_compat *dhc;
 
 	if ((ctx->options & (DHCPCD_MANAGER | DHCPCD_PRIVSEP)) ==
@@ -4019,25 +4053,23 @@ dhcp6_start1(void *arg)
 	state = D6_STATE(ifp);
 	/* If no DHCPv6 options are configured,
 	   match configured DHCPv4 options to DHCPv6 equivalents. */
-	for (i = 0; i < sizeof(ifo->requestmask6); i++) {
-		if (ifo->requestmask6[i] != '\0')
-			break;
-	}
-	if (i == sizeof(ifo->requestmask6)) {
+	if (pg->dhop_request.dhop_policy_len == 0) {
+		const struct dho_policy_group *dpg = &ifo->dhopg_dhcp;
+
 		for (dhc = dhcp_compats; dhc->dhcp_opt; dhc++) {
-			if (DHC_REQ(ifo->requestmask, ifo->nomask,
-				dhc->dhcp_opt))
-				add_option_mask(ifo->requestmask6,
+			if (dho_policy_allowed(dpg, dhc->dhcp_opt) &&
+			    dho_policy_has(&pg->dhop_request, dhc->dhcp_opt))
+				dho_policy_add(&pg->dhop_request,
 				    dhc->dhcp6_opt);
 		}
 		if (ifo->fqdn != FQDN_DISABLE || ifo->options & DHCPCD_HOSTNAME)
-			add_option_mask(ifo->requestmask6, D6_OPTION_FQDN);
+			dho_policy_add(&pg->dhop_request, D6_OPTION_FQDN);
 	}
 
 #ifndef SMALL
 	/* Rapid commit won't work with Prefix Delegation Exclusion */
 	if (dhcp6_findselfsla(ifp))
-		del_option_mask(ifo->requestmask6, D6_OPTION_RAPID_COMMIT);
+		dho_policy_del(&pg->dhop_request, D6_OPTION_RAPID_COMMIT);
 #endif
 
 	if (state->state == DH6S_INFORM)
@@ -4332,6 +4364,7 @@ dhcp6_env(FILE *fp, const char *prefix, const struct interface *ifp,
     const struct dhcp6_message *m, size_t len)
 {
 	const struct if_options *ifo;
+	const struct dho_policy_group *pg;
 	struct dhcp_opt *opt, *vo;
 	const uint8_t *p;
 	struct dhcp6_option o;
@@ -4356,6 +4389,7 @@ dhcp6_env(FILE *fp, const char *prefix, const struct interface *ifp,
 	}
 
 	ifo = ifp->options;
+	pg = &ifo->dhopg_dhcp6;
 	ctx = ifp->ctx;
 
 	/* Zero our indexes */
@@ -4387,7 +4421,7 @@ dhcp6_env(FILE *fp, const char *prefix, const struct interface *ifp,
 			break;
 		}
 		o.code = ntohs(o.code);
-		if (has_option_mask(ifo->nomask6, o.code))
+		if (!dho_policy_allowed(pg, o.code))
 			continue;
 		for (i = 0, opt = ifo->dhcp6_override;
 		    i < ifo->dhcp6_override_len; i++, opt++)

--- a/src/dhcpcd.conf.5.in
+++ b/src/dhcpcd.conf.5.in
@@ -23,7 +23,7 @@
 .\" OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
 .\" SUCH DAMAGE.
 .\"
-.Dd June 12, 2025
+.Dd June 29, 2026
 .Dt DHCPCD.CONF 5
 .Os
 .Sh NAME
@@ -61,13 +61,16 @@ which is a space or comma separated list of patterns passed to
 .It Ic anonymous
 Enables Anonymity Profiles for DHCP, RFC 7844.
 Any DUID is ignored and ClientID is set to LL only.
-All non essential options are then masked at this point,
-but they could be unmasked by explicitly requesting the option
-.Sy after
-the
-.Ic anonymous
-option is processed.
-As such, the
+Then
+.Nm
+will only
+.Ic allow
+essential options.
+Non essential options can be allowed by use of
+.Ic allow
+or
+.Ic request .
+The
 .Ic anonymous
 option
 .Sy should
@@ -646,18 +649,23 @@ then DHCPv4 options are mapped to equivalent DHCPv6 options.
 .Pp
 Prepend nd_ to
 .Ar option
-to handle ND options, but this only works for the
-.Ic nooption ,
-.Ic reject
-and
-.Ic require
-options.
+to handle ND options.
 .Pp
 To see a list of options you can use, call
 .Nm dhcpcd
 with the
 .Fl V , Fl Fl variables
 argument.
+.It Ic allow Ar option
+Opposite of
+.Ic nooption .
+If there are no
+.Ic allow
+options then we negate
+.Ic nooption
+when working out what options we can send and receive.
+.Ic option
+is always allowed.
 .It Ic nooption Ar option
 Remove the option from the message before it's processed.
 .It Ic require Ar option

--- a/src/if-options.c
+++ b/src/if-options.c
@@ -178,6 +178,7 @@ const struct option cf_options[] = { { "background", no_argument, NULL, 'b' },
 	{ "initial_interval", required_argument, NULL, O_INITIAL_INTERVAL },
 	{ "backoff_cutoff", required_argument, NULL, O_BACKOFF_CUTOFF },
 	{ "backoff_jitter", required_argument, NULL, O_BACKOFF_JITTER },
+	{ "allow", required_argument, NULL, O_ALLOW },
 	{ NULL, 0, NULL, '\0' } };
 
 static char *
@@ -507,10 +508,9 @@ parse_addr(__unused struct in_addr *addr, __unused struct in_addr *net,
 #endif
 
 static void
-set_option_space(struct dhcpcd_ctx *ctx, struct if_options *ifo, const char *arg,
-		struct dho_policy_ctx *pctx, struct dho_policy_group **pg)
+set_option_space(struct dhcpcd_ctx *ctx, struct if_options *ifo,
+    const char *arg, struct dho_policy_ctx *pctx, struct dho_policy_group **pg)
 {
-
 	if (strncmp(arg, "nd_", strlen("nd_")) == 0) {
 		pctx->dopts = ctx->nd_opts;
 		pctx->dopts_len = ctx->nd_opts_len;
@@ -605,6 +605,48 @@ strend(char *s)
 	return ++s;
 }
 #endif
+
+static int
+set_default_allow(struct if_options *ifo, struct dho_policy_group *pg)
+{
+	if (pg->dhop_allow.dhop_policy_len != 0)
+		return 0;
+
+	/* Allow the bare minimum through */
+#ifdef INET
+	if (pg == &ifo->dhopg_dhcp) {
+		struct dho_policy *p = &pg->dhop_allow;
+
+		if (dho_policy_add(p, DHO_SUBNETMASK) == -1 ||
+		    dho_policy_add(p, DHO_SUBNETMASK) == -1 ||
+		    dho_policy_add(p, DHO_CSR) == -1 ||
+		    dho_policy_add(p, DHO_ROUTER) == -1 ||
+		    dho_policy_add(p, DHO_DNSSERVER) == -1 ||
+		    dho_policy_add(p, DHO_DNSDOMAIN) == -1 ||
+		    dho_policy_add(p, DHO_BROADCAST) == -1 ||
+		    dho_policy_add(p, DHO_STATICROUTE) == -1 ||
+		    dho_policy_add(p, DHO_SERVERID) == -1 ||
+		    dho_policy_add(p, DHO_RENEWALTIME) == -1 ||
+		    dho_policy_add(p, DHO_REBINDTIME) == -1 ||
+		    dho_policy_add(p, DHO_DNSSEARCH) == -1)
+			return -1;
+	}
+#endif
+
+#ifdef DHCP6
+	if (pg == &ifo->dhopg_dhcp6) {
+		struct dho_policy *p = &pg->dhop_allow;
+
+		if (dho_policy_add(p, D6_OPTION_DNS_SERVERS) == -1 ||
+		    dho_policy_add(p, D6_OPTION_DOMAIN_LIST) == -1 ||
+		    dho_policy_add(p, D6_OPTION_SOL_MAX_RT) == -1 ||
+		    dho_policy_add(p, D6_OPTION_INF_MAX_RT))
+			return -1;
+	}
+#endif
+
+	return 0;
+}
 
 static int
 parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
@@ -822,7 +864,8 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 			}
 			i = parse_addr(&ifo->req_addr, &ifo->req_mask, arg);
 			if (p != NULL) {
-				/* Ensure the original string is preserved */
+				/* Ensure the original string is
+				 * preserved */
 				*p++ = '/';
 				if (i == 0)
 					i = parse_addr(&ifo->req_brd, NULL, p);
@@ -1031,7 +1074,8 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 			return -1;
 		}
 
-		/* If vendor starts with , then it is not encapsulated */
+		/* If vendor starts with , then it is not encapsulated
+		 */
 		if (p == arg) {
 			arg++;
 			s = parse_string((char *)ifo->vendor + 1,
@@ -1092,7 +1136,8 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 		p = UNCONST(arg);
 		// Generally it's --waitip=46, but some expect
 		// --waitip="4 6" to work as well.
-		// It's easier to allow it rather than have confusing docs.
+		// It's easier to allow it rather than have confusing
+		// docs.
 		while (p != NULL && p[0] != '\0') {
 			if (p[0] == '4' || p[1] == '4')
 				ifo->options |= DHCPCD_WAITIP4;
@@ -1153,12 +1198,12 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 			dl = hwaddr_aton(NULL, arg);
 			if (dl != 0) {
 				void *nduid = realloc(ctx->duid, dl);
-				if (nduid == NULL)
+				if (nduid == NULL) {
 					logerrx(__func__);
-				else {
-					ctx->duid = nduid;
-					ctx->duid_len = hwaddr_aton(nduid, arg);
+					return -1;
 				}
+				ctx->duid = nduid;
+				ctx->duid_len = hwaddr_aton(nduid, arg);
 			}
 		}
 		break;
@@ -1464,6 +1509,19 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 	case O_NOIPV6:
 		ifo->options &= ~DHCPCD_IPV6;
 		break;
+	case O_ALLOW:
+		ARG_REQUIRED;
+		if (ctx->options & DHCPCD_PRINT_PIDFILE)
+			break;
+		set_option_space(ctx, ifo, arg, &pctx, &pg);
+		set_default_allow(ifo, pg);
+		if (dho_policy_set(&pctx, &pg->dhop_allow, arg, 1) != 0 ||
+		    dho_policy_set(&pctx, &pg->dhop_remove, arg, -1) != 0 ||
+		    dho_policy_set(&pctx, &pg->dhop_reject, arg, -1) != 0) {
+			logerrx("unknown option: %s", arg);
+			return -1;
+		}
+		break;
 	case O_ANONYMOUS:
 		ifo->options |= DHCPCD_ANONYMOUS;
 		ifo->options &= ~DHCPCD_HOSTNAME;
@@ -1471,27 +1529,11 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 
 		/* Allow the bare minimum through */
 #ifdef INET
-		pg = &ifo->dhopg_dhcp;
-		dho_policy_add(&pg->dhop_allow, DHO_SUBNETMASK);	
-		dho_policy_add(&pg->dhop_allow, DHO_SUBNETMASK);
-		dho_policy_add(&pg->dhop_allow, DHO_CSR);
-		dho_policy_add(&pg->dhop_allow, DHO_ROUTER);
-		dho_policy_add(&pg->dhop_allow, DHO_DNSSERVER);
-		dho_policy_add(&pg->dhop_allow, DHO_DNSDOMAIN);
-		dho_policy_add(&pg->dhop_allow, DHO_BROADCAST);
-		dho_policy_add(&pg->dhop_allow, DHO_STATICROUTE);
-		dho_policy_add(&pg->dhop_allow, DHO_SERVERID);
-		dho_policy_add(&pg->dhop_allow, DHO_RENEWALTIME);
-		dho_policy_add(&pg->dhop_allow, DHO_REBINDTIME);
-		dho_policy_add(&pg->dhop_allow, DHO_DNSSEARCH);
+		set_default_allow(ifo, &ifo->dhopg_dhcp);
 #endif
 
 #ifdef DHCP6
-		pg = &ifo->dhopg_dhcp6;
-		dho_policy_add(&pg->dhop_allow, D6_OPTION_DNS_SERVERS);
-		dho_policy_add(&pg->dhop_allow, D6_OPTION_DOMAIN_LIST);
-		dho_policy_add(&pg->dhop_allow, D6_OPTION_SOL_MAX_RT);
-		dho_policy_add(&pg->dhop_allow, D6_OPTION_INF_MAX_RT);
+		set_default_allow(ifo, &ifo->dhopg_dhcp6);
 #endif
 
 		break;
@@ -1522,7 +1564,8 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 		if (ctx->options & DHCPCD_PRINT_PIDFILE)
 			break;
 		set_option_space(ctx, ifo, arg, &pctx, &pg);
-		if (dho_policy_set(&pctx, &ifo->dhop_destination, arg, 2) != 0) {
+		if (dho_policy_set(&pctx, &ifo->dhop_destination, arg, 2) !=
+		    0) {
 			if (errno == EINVAL)
 				logerrx("option does not take"
 					" an IPv4 address: %s",
@@ -2627,10 +2670,11 @@ finish_config(struct if_options *ifo)
 		    DHCPCD_IPV6RA_AUTOCONF | DHCPCD_IPV6RA_REQRDNSS);
 
 #ifdef INET
-	/* The exponential backoff cutoff must not be lower than the initial
-	 * interval, otherwise the retransmission sequence would shrink rather
-	 * than grow up to the cap. Clamp the cutoff up to the initial
-	 * interval to preserve the documented "cap" semantics. */
+	/* The exponential backoff cutoff must not be lower than the
+	 * initial interval, otherwise the retransmission sequence would
+	 * shrink rather than grow up to the cap. Clamp the cutoff up to
+	 * the initial interval to preserve the documented "cap"
+	 * semantics. */
 	if (ifo->backoff_cutoff < ifo->initial_interval) {
 		logwarnx("backoff_cutoff (%u) is less than initial_interval "
 			 "(%u); raising backoff_cutoff to match",
@@ -2924,8 +2968,8 @@ read_config(struct dhcpcd_ctx *ctx, const char *ifname, const char *ssid,
 				skip = 1;
 			continue;
 		}
-		/* Skip arping if we have selected a profile but not parsing
-		 * one. */
+		/* Skip arping if we have selected a profile but not
+		 * parsing one. */
 		if (profile && !have_profile && strcmp(option, "arping") == 0)
 			continue;
 		if (skip)
@@ -3063,9 +3107,9 @@ free_options(struct dhcpcd_ctx *ctx, struct if_options *ifo)
 	dho_policy_group_free(ifo->dhopg_dhcp6);
 
 #ifdef RT_FREE_ROUTE_TABLE
-	/* Stupidly, we don't know the interface when creating the options.
-	 * As such, make sure each route has one so they can goto the
-	 * free list. */
+	/* Stupidly, we don't know the interface when creating the
+	 * options. As such, make sure each route has one so they can
+	 * goto the free list. */
 	ifp = ctx->ifaces != NULL ? TAILQ_FIRST(ctx->ifaces) : NULL;
 	if (ifp != NULL) {
 		RB_TREE_FOREACH(rt, &ifo->routes)

--- a/src/if-options.c
+++ b/src/if-options.c
@@ -640,7 +640,7 @@ set_default_allow(struct if_options *ifo, struct dho_policy_group *pg)
 		if (dho_policy_add(p, D6_OPTION_DNS_SERVERS) == -1 ||
 		    dho_policy_add(p, D6_OPTION_DOMAIN_LIST) == -1 ||
 		    dho_policy_add(p, D6_OPTION_SOL_MAX_RT) == -1 ||
-		    dho_policy_add(p, D6_OPTION_INF_MAX_RT))
+		    dho_policy_add(p, D6_OPTION_INF_MAX_RT) == -1)
 			return -1;
 	}
 #endif

--- a/src/if-options.c
+++ b/src/if-options.c
@@ -507,60 +507,33 @@ parse_addr(__unused struct in_addr *addr, __unused struct in_addr *net,
 #endif
 
 static void
-set_option_space(struct dhcpcd_ctx *ctx, const char *arg,
-    const struct dhcp_opt **d, size_t *dl, const struct dhcp_opt **od,
-    size_t *odl, struct if_options *ifo, uint8_t *request[], uint8_t *require[],
-    uint8_t *no[], uint8_t *reject[])
+set_option_space(struct dhcpcd_ctx *ctx, struct if_options *ifo, const char *arg,
+		struct dho_policy_ctx *pctx, struct dho_policy_group **pg)
 {
-#if !defined(INET) && !defined(INET6)
-	UNUSED(ctx);
-#endif
 
-#ifdef INET6
 	if (strncmp(arg, "nd_", strlen("nd_")) == 0) {
-		*d = ctx->nd_opts;
-		*dl = ctx->nd_opts_len;
-		*od = ifo->nd_override;
-		*odl = ifo->nd_override_len;
-		*request = ifo->requestmasknd;
-		*require = ifo->requiremasknd;
-		*no = ifo->nomasknd;
-		*reject = ifo->rejectmasknd;
+		pctx->dopts = ctx->nd_opts;
+		pctx->dopts_len = ctx->nd_opts_len;
+		pctx->odopts = ifo->nd_override;
+		pctx->odopts_len = ifo->nd_override_len;
+		*pg = &ifo->dhopg_nd;
 		return;
 	}
 
-#ifdef DHCP6
 	if (strncmp(arg, "dhcp6_", strlen("dhcp6_")) == 0) {
-		*d = ctx->dhcp6_opts;
-		*dl = ctx->dhcp6_opts_len;
-		*od = ifo->dhcp6_override;
-		*odl = ifo->dhcp6_override_len;
-		*request = ifo->requestmask6;
-		*require = ifo->requiremask6;
-		*no = ifo->nomask6;
-		*reject = ifo->rejectmask6;
+		pctx->dopts = ctx->dhcp6_opts;
+		pctx->dopts_len = ctx->dhcp6_opts_len;
+		pctx->odopts = ifo->dhcp6_override;
+		pctx->odopts_len = ifo->dhcp6_override_len;
+		*pg = &ifo->dhopg_dhcp6;
 		return;
 	}
-#endif
-#else
-	UNUSED(arg);
-#endif
 
-#ifdef INET
-	*d = ctx->dhcp_opts;
-	*dl = ctx->dhcp_opts_len;
-	*od = ifo->dhcp_override;
-	*odl = ifo->dhcp_override_len;
-#else
-	*d = NULL;
-	*dl = 0;
-	*od = NULL;
-	*odl = 0;
-#endif
-	*request = ifo->requestmask;
-	*require = ifo->requiremask;
-	*no = ifo->nomask;
-	*reject = ifo->rejectmask;
+	pctx->dopts = ctx->dhcp_opts;
+	pctx->dopts_len = ctx->dhcp_opts_len;
+	pctx->odopts = ifo->dhcp_override;
+	pctx->odopts_len = ifo->dhcp_override_len;
+	*pg = &ifo->dhopg_dhcp;
 }
 
 void
@@ -644,10 +617,10 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 	ssize_t s;
 	struct in_addr addr, addr2;
 	in_addr_t *naddr;
-	const struct dhcp_opt *d, *od;
-	uint8_t *request, *require, *no, *reject;
+	struct dho_policy_group *pg;
+	struct dho_policy_ctx pctx;
 	struct dhcp_opt **dop, *ndop;
-	size_t *dop_len, dl, odl;
+	size_t *dop_len, dl;
 	struct group *grp;
 #ifdef AUTH
 	struct token *token;
@@ -809,11 +782,10 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 		ARG_REQUIRED;
 		if (ctx->options & DHCPCD_PRINT_PIDFILE)
 			break;
-		set_option_space(ctx, arg, &d, &dl, &od, &odl, ifo, &request,
-		    &require, &no, &reject);
-		if (make_option_mask(d, dl, od, odl, request, arg, 1) != 0 ||
-		    make_option_mask(d, dl, od, odl, no, arg, -1) != 0 ||
-		    make_option_mask(d, dl, od, odl, reject, arg, -1) != 0) {
+		set_option_space(ctx, ifo, arg, &pctx, &pg);
+		if (dho_policy_set(&pctx, &pg->dhop_request, arg, 1) != 0 ||
+		    dho_policy_set(&pctx, &pg->dhop_remove, arg, -1) != 0 ||
+		    dho_policy_set(&pctx, &pg->dhop_reject, arg, -1) != 0) {
 			logerrx("unknown option: %s", arg);
 			return -1;
 		}
@@ -822,11 +794,10 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 		ARG_REQUIRED;
 		if (ctx->options & DHCPCD_PRINT_PIDFILE)
 			break;
-		set_option_space(ctx, arg, &d, &dl, &od, &odl, ifo, &request,
-		    &require, &no, &reject);
-		if (make_option_mask(d, dl, od, odl, reject, arg, 1) != 0 ||
-		    make_option_mask(d, dl, od, odl, request, arg, -1) != 0 ||
-		    make_option_mask(d, dl, od, odl, require, arg, -1) != 0) {
+		set_option_space(ctx, ifo, arg, &pctx, &pg);
+		if (dho_policy_set(&pctx, &pg->dhop_reject, arg, 1) != 0 ||
+		    dho_policy_set(&pctx, &pg->dhop_request, arg, -1) != 0 ||
+		    dho_policy_set(&pctx, &pg->dhop_require, arg, -1) != 0) {
 			logerrx("unknown option: %s", arg);
 			return -1;
 		}
@@ -1181,12 +1152,12 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 		else {
 			dl = hwaddr_aton(NULL, arg);
 			if (dl != 0) {
-				no = realloc(ctx->duid, dl);
-				if (no == NULL)
+				void *nduid = realloc(ctx->duid, dl);
+				if (nduid == NULL)
 					logerrx(__func__);
 				else {
-					ctx->duid = no;
-					ctx->duid_len = hwaddr_aton(no, arg);
+					ctx->duid = nduid;
+					ctx->duid_len = hwaddr_aton(nduid, arg);
 				}
 			}
 		}
@@ -1252,11 +1223,10 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 		ARG_REQUIRED;
 		if (ctx->options & DHCPCD_PRINT_PIDFILE)
 			break;
-		set_option_space(ctx, arg, &d, &dl, &od, &odl, ifo, &request,
-		    &require, &no, &reject);
-		if (make_option_mask(d, dl, od, odl, request, arg, -1) != 0 ||
-		    make_option_mask(d, dl, od, odl, require, arg, -1) != 0 ||
-		    make_option_mask(d, dl, od, odl, no, arg, 1) != 0) {
+		set_option_space(ctx, ifo, arg, &pctx, &pg);
+		if (dho_policy_set(&pctx, &pg->dhop_request, arg, -1) != 0 ||
+		    dho_policy_set(&pctx, &pg->dhop_require, arg, -1) != 0 ||
+		    dho_policy_set(&pctx, &pg->dhop_remove, arg, 1) != 0) {
 			logerrx("unknown option: %s", arg);
 			return -1;
 		}
@@ -1265,12 +1235,11 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 		ARG_REQUIRED;
 		if (ctx->options & DHCPCD_PRINT_PIDFILE)
 			break;
-		set_option_space(ctx, arg, &d, &dl, &od, &odl, ifo, &request,
-		    &require, &no, &reject);
-		if (make_option_mask(d, dl, od, odl, require, arg, 1) != 0 ||
-		    make_option_mask(d, dl, od, odl, request, arg, 1) != 0 ||
-		    make_option_mask(d, dl, od, odl, no, arg, -1) != 0 ||
-		    make_option_mask(d, dl, od, odl, reject, arg, -1) != 0) {
+		set_option_space(ctx, ifo, arg, &pctx, &pg);
+		if (dho_policy_set(&pctx, &pg->dhop_require, arg, 1) != 0 ||
+		    dho_policy_set(&pctx, &pg->dhop_request, arg, 1) != 0 ||
+		    dho_policy_set(&pctx, &pg->dhop_remove, arg, -1) != 0 ||
+		    dho_policy_set(&pctx, &pg->dhop_reject, arg, -1) != 0) {
 			logerrx("unknown option: %s", arg);
 			return -1;
 		}
@@ -1500,30 +1469,29 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 		ifo->options &= ~DHCPCD_HOSTNAME;
 		ifo->fqdn = FQDN_DISABLE;
 
-		/* Block everything */
-		memset(ifo->nomask, 0xff, sizeof(ifo->nomask));
-		memset(ifo->nomask6, 0xff, sizeof(ifo->nomask6));
-
 		/* Allow the bare minimum through */
 #ifdef INET
-		del_option_mask(ifo->nomask, DHO_SUBNETMASK);
-		del_option_mask(ifo->nomask, DHO_CSR);
-		del_option_mask(ifo->nomask, DHO_ROUTER);
-		del_option_mask(ifo->nomask, DHO_DNSSERVER);
-		del_option_mask(ifo->nomask, DHO_DNSDOMAIN);
-		del_option_mask(ifo->nomask, DHO_BROADCAST);
-		del_option_mask(ifo->nomask, DHO_STATICROUTE);
-		del_option_mask(ifo->nomask, DHO_SERVERID);
-		del_option_mask(ifo->nomask, DHO_RENEWALTIME);
-		del_option_mask(ifo->nomask, DHO_REBINDTIME);
-		del_option_mask(ifo->nomask, DHO_DNSSEARCH);
+		pg = &ifo->dhopg_dhcp;
+		dho_policy_add(&pg->dhop_allow, DHO_SUBNETMASK);	
+		dho_policy_add(&pg->dhop_allow, DHO_SUBNETMASK);
+		dho_policy_add(&pg->dhop_allow, DHO_CSR);
+		dho_policy_add(&pg->dhop_allow, DHO_ROUTER);
+		dho_policy_add(&pg->dhop_allow, DHO_DNSSERVER);
+		dho_policy_add(&pg->dhop_allow, DHO_DNSDOMAIN);
+		dho_policy_add(&pg->dhop_allow, DHO_BROADCAST);
+		dho_policy_add(&pg->dhop_allow, DHO_STATICROUTE);
+		dho_policy_add(&pg->dhop_allow, DHO_SERVERID);
+		dho_policy_add(&pg->dhop_allow, DHO_RENEWALTIME);
+		dho_policy_add(&pg->dhop_allow, DHO_REBINDTIME);
+		dho_policy_add(&pg->dhop_allow, DHO_DNSSEARCH);
 #endif
 
 #ifdef DHCP6
-		del_option_mask(ifo->nomask6, D6_OPTION_DNS_SERVERS);
-		del_option_mask(ifo->nomask6, D6_OPTION_DOMAIN_LIST);
-		del_option_mask(ifo->nomask6, D6_OPTION_SOL_MAX_RT);
-		del_option_mask(ifo->nomask6, D6_OPTION_INF_MAX_RT);
+		pg = &ifo->dhopg_dhcp6;
+		dho_policy_add(&pg->dhop_allow, D6_OPTION_DNS_SERVERS);
+		dho_policy_add(&pg->dhop_allow, D6_OPTION_DOMAIN_LIST);
+		dho_policy_add(&pg->dhop_allow, D6_OPTION_SOL_MAX_RT);
+		dho_policy_add(&pg->dhop_allow, D6_OPTION_INF_MAX_RT);
 #endif
 
 		break;
@@ -1553,10 +1521,8 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 		ARG_REQUIRED;
 		if (ctx->options & DHCPCD_PRINT_PIDFILE)
 			break;
-		set_option_space(ctx, arg, &d, &dl, &od, &odl, ifo, &request,
-		    &require, &no, &reject);
-		if (make_option_mask(d, dl, od, odl, ifo->dstmask, arg, 2) !=
-		    0) {
+		set_option_space(ctx, ifo, arg, &pctx, &pg);
+		if (dho_policy_set(&pctx, &ifo->dhop_destination, arg, 2) != 0) {
 			if (errno == EINVAL)
 				logerrx("option does not take"
 					" an IPv4 address: %s",
@@ -3089,6 +3055,12 @@ free_options(struct dhcpcd_ctx *ctx, struct if_options *ifo)
 			free(ifo->config[i++]);
 		free(ifo->config);
 	}
+
+	dho_policy_group_free(ifo->dhopg_dhcp);
+	dho_policy_free(ifo->dhop_destination);
+
+	dho_policy_group_free(ifo->dhopg_nd);
+	dho_policy_group_free(ifo->dhopg_dhcp6);
 
 #ifdef RT_FREE_ROUTE_TABLE
 	/* Stupidly, we don't know the interface when creating the options.

--- a/src/if-options.c
+++ b/src/if-options.c
@@ -1514,7 +1514,10 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 		if (ctx->options & DHCPCD_PRINT_PIDFILE)
 			break;
 		set_option_space(ctx, ifo, arg, &pctx, &pg);
-		set_default_allow(ifo, pg);
+		if (set_default_allow(ifo, pg)) {
+			logerr("%s: set_default_allow", __func__);
+			return -1;
+		}
 		if (dho_policy_set(&pctx, &pg->dhop_allow, arg, 1) != 0 ||
 		    dho_policy_set(&pctx, &pg->dhop_remove, arg, -1) != 0 ||
 		    dho_policy_set(&pctx, &pg->dhop_reject, arg, -1) != 0) {
@@ -1529,11 +1532,17 @@ parse_option(struct dhcpcd_ctx *ctx, const char *ifname, struct if_options *ifo,
 
 		/* Allow the bare minimum through */
 #ifdef INET
-		set_default_allow(ifo, &ifo->dhopg_dhcp);
+		if (set_default_allow(ifo, &ifo->dhopg_dhcp) == -1) {
+			logerr("%s: set_defaut_allow DHCP", __func__);
+			return -1;
+		}
 #endif
 
 #ifdef DHCP6
-		set_default_allow(ifo, &ifo->dhopg_dhcp6);
+		if (set_default_allow(ifo, &ifo->dhopg_dhcp6) == -1) {
+			logerr("%s: set_default_allow DHCPv6", __func__);
+			return -1;
+		}
 #endif
 
 		break;

--- a/src/if-options.h
+++ b/src/if-options.h
@@ -247,23 +247,24 @@ struct vsio {
 };
 #endif
 
+#define OPTION_POLICY_MAX 5
+struct dho_policy {
+	uint32_t *dhop_policy;
+	size_t dhop_policy_len;
+};
+
+struct dho_policy_group {
+	struct dho_policy dhop_request;
+	struct dho_policy dhop_require;
+	struct dho_policy dhop_allow;
+	struct dho_policy dhop_remove;
+	struct dho_policy dhop_reject;
+};
+
 struct if_options {
 	time_t mtime;
 	uint8_t iaid[4];
 	int metric;
-	uint8_t requestmask[256 / NBBY];
-	uint8_t requiremask[256 / NBBY];
-	uint8_t nomask[256 / NBBY];
-	uint8_t rejectmask[256 / NBBY];
-	uint8_t dstmask[256 / NBBY];
-	uint8_t requestmasknd[(UINT16_MAX + 1) / NBBY];
-	uint8_t requiremasknd[(UINT16_MAX + 1) / NBBY];
-	uint8_t nomasknd[(UINT16_MAX + 1) / NBBY];
-	uint8_t rejectmasknd[(UINT16_MAX + 1) / NBBY];
-	uint8_t requestmask6[(UINT16_MAX + 1) / NBBY];
-	uint8_t requiremask6[(UINT16_MAX + 1) / NBBY];
-	uint8_t nomask6[(UINT16_MAX + 1) / NBBY];
-	uint8_t rejectmask6[(UINT16_MAX + 1) / NBBY];
 	uint32_t leasetime;
 	uint32_t timeout;
 	uint32_t reboot;
@@ -275,6 +276,12 @@ struct if_options {
 	uint32_t backoff_jitter;
 	unsigned long long options;
 	bool randomise_hwaddr;
+
+	struct dho_policy_group dhopg_dhcp;
+	struct dho_policy dhop_destination;
+
+	struct dho_policy_group dhopg_nd;
+	struct dho_policy_group dhopg_dhcp6;
 
 	struct in_addr req_addr;
 	struct in_addr req_mask;

--- a/src/if-options.h
+++ b/src/if-options.h
@@ -203,6 +203,7 @@
 #define O_INITIAL_INTERVAL   O_BASE + 60
 #define O_BACKOFF_CUTOFF     O_BASE + 61
 #define O_BACKOFF_JITTER     O_BASE + 62
+#define O_ALLOW		     O_BASE + 63
 
 extern const struct option cf_options[];
 

--- a/src/ipv4.c
+++ b/src/ipv4.c
@@ -338,7 +338,7 @@ inet_dhcproutes(rb_tree_t *routes, struct interface *ifp, bool *have_default)
 	/* If configured, install a gateway to the desintion
 	 * for P2P interfaces. */
 	if (ifp->flags & IFF_POINTOPOINT &&
-	    has_option_mask(ifp->options->dstmask, DHO_ROUTER)) {
+	    dho_policy_has(&ifp->options->dhop_destination, DHO_ROUTER)) {
 		if ((rt = rt_new(ifp)) == NULL)
 			return -1;
 		in.s_addr = INADDR_ANY;

--- a/src/ipv6nd.c
+++ b/src/ipv6nd.c
@@ -944,29 +944,74 @@ dhcp6_start(__unused struct interface *ifp, __unused enum DH6S init_state)
 }
 #endif
 
+struct nd_policy_ctx {
+	struct dhcpcd_ctx *ctx;
+	int loglevel;
+	const char *ifname;
+	const char *sfrom;
+	struct icmp6_hdr *icp;
+	size_t len;
+};
+
+static int
+nd_require(uint32_t option, void *arg)
+{
+	struct nd_policy_ctx *nd_ctx = arg;
+	size_t len = nd_ctx->len, olen;
+	uint8_t *p;
+	struct nd_opt_hdr ndo;
+
+	struct dhcpcd_ctx *ctx = nd_ctx->ctx;
+	const char *soption;
+
+	len -= sizeof(struct nd_router_advert);
+	p = ((uint8_t *)nd_ctx->icp) + sizeof(struct nd_router_advert);
+	for (; len > 0; p += olen, len -= olen) {
+		if (len < sizeof(ndo))
+			break;
+		memcpy(&ndo, p, sizeof(ndo));
+		olen = (size_t)ndo.nd_opt_len * 8;
+		if (olen > len)
+			break;
+		if (ndo.nd_opt_type == option)
+			return 0;
+	}
+
+	soption = dhcp_option_string(ctx->nd_opts, ctx->nd_opts_len, option);
+	logmessage(nd_ctx->loglevel,
+	    "%s: reject RA (missing option %s) from %s", nd_ctx->ifname,
+	    soption, nd_ctx->sfrom);
+	return -1;
+}
+
 static void
 ipv6nd_handlera(struct dhcpcd_ctx *ctx, const struct sockaddr_in6 *from,
     const char *sfrom, struct interface *ifp, struct icmp6_hdr *icp, size_t len,
     int hoplimit)
 {
-	size_t i, olen, rlen;
+	size_t olen, rlen;
 	struct nd_router_advert *nd_ra;
 	struct nd_opt_hdr ndo;
+	struct nd_policy_ctx policy = {
+		.ctx = ctx,
+		.icp = icp,
+		.len = len,
+		.sfrom = sfrom,
+	};
 	struct nd_opt_prefix_info pi;
 	struct nd_opt_mtu mtu;
 	struct nd_opt_rdnss rdnss;
 	struct nd_opt_ri ri;
 	struct routeinfo *rinfo;
 	struct if_options *ifo;
+	const struct dho_policy_group *pg;
 	uint8_t *p;
 	struct ra *rap;
 	struct in6_addr pi_prefix;
 	struct ipv6_addr *ia;
-	struct dhcp_opt *dho;
-	bool new_rap, new_data, has_address, has_opt;
+	bool new_rap, new_data, has_address;
 	uint32_t old_lifetime;
-	int ifmtu;
-	int loglevel;
+	int err, ifmtu, loglevel;
 	unsigned int flags;
 #ifdef IPV6_MANAGETEMPADDR
 	bool new_ia;
@@ -1042,11 +1087,16 @@ ipv6nd_handlera(struct dhcpcd_ctx *ctx, const struct sockaddr_in6 *from,
 
 	nd_ra = (struct nd_router_advert *)icp;
 
-	/* Validate */
 	loglevel = rap == NULL || rap->willexpire || !rap->isreachable ?
 	    LOG_ERR :
 	    LOG_DEBUG;
+
+	policy.loglevel = loglevel;
+	policy.ifname = ifp->name;
 	ifo = ifp->options;
+	pg = &ifo->dhopg_nd;
+
+	/* Validate */
 	rlen = len;
 	len -= sizeof(struct nd_router_advert);
 	p = ((uint8_t *)icp) + sizeof(struct nd_router_advert);
@@ -1071,50 +1121,20 @@ ipv6nd_handlera(struct dhcpcd_ctx *ctx, const struct sockaddr_in6 *from,
 			break;
 		}
 
-		if (has_option_mask(ifo->rejectmasknd, ndo.nd_opt_type)) {
-			for (i = 0, dho = ctx->nd_opts; i < ctx->nd_opts_len;
-			    i++, dho++) {
-				if (dho->option == ndo.nd_opt_type)
-					break;
-			}
-			if (i == ctx->nd_opts_len)
-				logmessage(loglevel,
-				    "%s: reject RA (option %d) from %s",
-				    ifp->name, ndo.nd_opt_type, sfrom);
-			else
-				logmessage(loglevel,
-				    "%s: reject RA (option %s) from %s",
-				    ifp->name, dho->var, sfrom);
+		if (!dho_policy_allowed(pg, ndo.nd_opt_type)) {
+			const char *soption = dhcp_option_string(ctx->nd_opts,
+			    ctx->nd_opts_len, ndo.nd_opt_type);
+			logmessage(loglevel,
+			    "%s: reject RA (option %s) from %s", ifp->name,
+			    soption, sfrom);
 			return;
 		}
 	}
-
-	for (i = 0, dho = ctx->nd_opts; i < ctx->nd_opts_len; i++, dho++) {
-		if (!has_option_mask(ifo->requiremasknd, dho->option))
-			continue;
-		len = rlen;
-		len -= sizeof(struct nd_router_advert);
-		p = ((uint8_t *)icp) + sizeof(struct nd_router_advert);
-		has_opt = false;
-		for (; len > 0; p += olen, len -= olen) {
-			if (len < sizeof(ndo))
-				break;
-			memcpy(&ndo, p, sizeof(ndo));
-			olen = (size_t)ndo.nd_opt_len * 8;
-			if (olen > len)
-				break;
-			if (ndo.nd_opt_type == dho->option) {
-				has_opt = true;
-				break;
-			}
-		}
-		if (has_opt)
-			continue;
-		logmessage(loglevel, "%s: reject RA (missing %s) from %s",
-		    ifp->name, dho->var, sfrom);
-		return;
-	}
 	len = rlen;
+
+	err = dho_policy_check(&pg->dhop_require, nd_require, &policy);
+	if (err == -1)
+		return;
 
 	/* We don't want to spam the log with the fact we got an RA every
 	 * 30 seconds or so, so only spam the log if it's different. */
@@ -1207,7 +1227,7 @@ ipv6nd_handlera(struct dhcpcd_ctx *ctx, const struct sockaddr_in6 *from,
 		if (olen > len)
 			break;
 
-		if (has_option_mask(ifp->options->nomasknd, ndo.nd_opt_type))
+		if (!dho_policy_allowed(pg, ndo.nd_opt_type))
 			continue;
 
 		switch (ndo.nd_opt_type) {
@@ -1613,12 +1633,14 @@ ipv6nd_env(FILE *fp, const struct interface *ifp)
 	struct ipv6_addr *ia;
 	struct timespec now;
 	int pref;
+	const struct dho_policy_group *pg;
 
 	clock_gettime(CLOCK_MONOTONIC, &now);
 	i = n = 0;
 	TAILQ_FOREACH(rap, ifp->ctx->ra_routers, next) {
 		if (rap->iface != ifp || rap->expired)
 			continue;
+		pg = &rap->iface->options->dhopg_nd;
 		i++;
 		snprintf(ndprefix, sizeof(ndprefix), "nd%zu", i);
 		if (efprintf(fp, "%s_from=%s", ndprefix, rap->sfrom) == -1)
@@ -1666,7 +1688,7 @@ ipv6nd_env(FILE *fp, const struct interface *ifp)
 				errno = EINVAL;
 				break;
 			}
-			if (has_option_mask(rap->iface->options->nomasknd,
+			if (!dho_policy_allowed(pg,
 				ndo.nd_opt_type))
 				continue;
 			for (j = 0, opt = rap->iface->options->nd_override;
@@ -1730,6 +1752,7 @@ void
 ipv6nd_expirera(void *arg)
 {
 	struct interface *ifp;
+	const struct dho_policy_group *pg;
 	struct ra *rap, *ran;
 	struct timespec now;
 	bool expired, valid;
@@ -1754,6 +1777,7 @@ ipv6nd_expirera(void *arg)
 		if (rap->iface != ifp || rap->expired)
 			continue;
 		valid = false;
+		pg = &rap->iface->options->dhopg_nd;
 		/* lifetime may be set to infinite by rfc4191 route information
 		 */
 		if (rap->lifetime) {
@@ -1831,7 +1855,7 @@ ipv6nd_expirera(void *arg)
 				break;
 			}
 
-			if (has_option_mask(rap->iface->options->nomasknd,
+			if (dho_policy_allowed(pg,
 				ndo.nd_opt_type))
 				continue;
 

--- a/src/ipv6nd.c
+++ b/src/ipv6nd.c
@@ -1688,8 +1688,7 @@ ipv6nd_env(FILE *fp, const struct interface *ifp)
 				errno = EINVAL;
 				break;
 			}
-			if (!dho_policy_allowed(pg,
-				ndo.nd_opt_type))
+			if (!dho_policy_allowed(pg, ndo.nd_opt_type))
 				continue;
 			for (j = 0, opt = rap->iface->options->nd_override;
 			    j < rap->iface->options->nd_override_len;
@@ -1855,8 +1854,7 @@ ipv6nd_expirera(void *arg)
 				break;
 			}
 
-			if (dho_policy_allowed(pg,
-				ndo.nd_opt_type))
+			if (!dho_policy_allowed(pg, ndo.nd_opt_type))
 				continue;
 
 			switch (ndo.nd_opt_type) {


### PR DESCRIPTION
Remove the old bitmask array which we used to store which options to request, remove, require, etc and replace with a more generic policy group.

The policy group structure holds an array of option numbers in each list - request, remove, require, etc.
Add a suite of helper functions around this to allow adding, removing, checking, walking, etc.

This allows a much easier use of this in DHCP processing but more importantly allows us to remove or reject options we do not have a definition for.