### PR TITLE
keep acquisition timestamp when route isn't updated

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,9 +51,6 @@ jobs:
     - name: Update packages
       run: sudo apt update
 
-    - name: Upgrade packages
-      run: sudo apt upgrade -y
-
     - name: Install libudev-dev
       run: sudo apt install -y libudev-dev
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,12 @@ jobs:
     runs-on: ${{ matrix.os }}
 
     steps:
+    - name: Update packages
+      run: sudo apt update
+
+    - name: Upgrade packages
+      run: sudo apt upgrade -y
+
     - name: Install libudev-dev
       run: sudo apt install -y libudev-dev
 

--- a/src/if-linux.c
+++ b/src/if-linux.c
@@ -1783,7 +1783,8 @@ if_route(unsigned char cmd, const struct rt *rt)
 	if (rt->rt_lifetime != 0) {
 		uint32_t expires;
 
-		expires = lifetime_left(rt->rt_lifetime, &rt->rt_acquired, NULL);
+		expires = lifetime_left(rt->rt_lifetime, &rt->rt_acquired,
+		    NULL);
 		add_attr_32(&nlm.hdr, sizeof(nlm), RTA_EXPIRES, expires);
 	}
 #endif

--- a/src/if-linux.c
+++ b/src/if-linux.c
@@ -1783,7 +1783,7 @@ if_route(unsigned char cmd, const struct rt *rt)
 	if (rt->rt_lifetime != 0) {
 		uint32_t expires;
 
-		expires = lifetime_left(rt->rt_lifetime, &rt->rt_aquired, NULL);
+		expires = lifetime_left(rt->rt_lifetime, &rt->rt_acquired, NULL);
 		add_attr_32(&nlm.hdr, sizeof(nlm), RTA_EXPIRES, expires);
 	}
 #endif

--- a/src/ipv6.c
+++ b/src/ipv6.c
@@ -2308,7 +2308,7 @@ inet6_raroutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx)
 			rt->rt_pref = ipv6nd_rtpref(rinfo->flags);
 #endif
 #ifdef HAVE_ROUTE_LIFETIME
-			rt->rt_aquired = rinfo->acquired;
+			rt->rt_acquired = rinfo->acquired;
 			rt->rt_lifetime = rinfo->lifetime,
 #endif
 			rt_proto_add(routes, rt);
@@ -2325,7 +2325,7 @@ inet6_raroutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx)
 				rt->rt_pref = ipv6nd_rtpref(rap->flags);
 #endif
 #ifdef HAVE_ROUTE_LIFETIME
-				rt->rt_aquired = addr->acquired;
+				rt->rt_acquired = addr->acquired;
 				rt->rt_lifetime = addr->prefix_vltime;
 #endif
 
@@ -2361,7 +2361,7 @@ inet6_raroutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx)
 		rt->rt_pref = ipv6nd_rtpref(rap->flags);
 #endif
 #ifdef HAVE_ROUTE_LIFETIME
-		rt->rt_aquired = rap->acquired;
+		rt->rt_acquired = rap->acquired;
 		rt->rt_lifetime = rap->lifetime;
 #endif
 
@@ -2400,7 +2400,7 @@ inet6_dhcproutes(rb_tree_t *routes, struct dhcpcd_ctx *ctx, enum DH6S dstate)
 				continue;
 			rt->rt_dflags |= RTDF_DHCP;
 #ifdef HAVE_ROUTE_LIFETIME
-			rt->rt_aquired = ia->acquired;
+			rt->rt_acquired = ia->acquired;
 			rt->rt_lifetime = ia->prefix_vltime;
 #endif
 			rt_proto_add(routes, rt);

--- a/src/route.c
+++ b/src/route.c
@@ -558,7 +558,7 @@ rt_cmp_lifetime(struct rt *nrt, struct rt *ort)
 	struct timespec ts;
 	uint32_t deviation;
 
-	timespecsub(&nrt->rt_aquired, &ort->rt_aquired, &ts);
+	timespecsub(&nrt->rt_acquired, &ort->rt_acquired, &ts);
 	if (ts.tv_sec < 0)
 		ts.tv_sec = -ts.tv_sec;
 	if (ts.tv_sec > RTLIFETIME_DEV_MAX)

--- a/src/route.c
+++ b/src/route.c
@@ -755,6 +755,11 @@ rt_doroute(rb_tree_t *kroutes, struct rt *rt)
 				return false;
 		} else {
 #ifdef HAVE_ROUTE_LIFETIME
+			/* The existing kernel route matches what we want
+			 * and the lifetime is inside the allowed deviation.
+			 * Persist the original acquisition time so the
+			 * deviaton can drop outside what is allowed and the
+			 * kernel route is re-added with a new lifetime. */
 			rt->rt_acquired = or->rt_acquired;
 #endif
 		}

--- a/src/route.c
+++ b/src/route.c
@@ -753,7 +753,12 @@ rt_doroute(rb_tree_t *kroutes, struct rt *rt)
 		    rt_cmp_mtu(rt, or) != 0) {
 			if (!rt_add(kroutes, rt, or))
 				return false;
+		} else {
+#ifdef HAVE_ROUTE_LIFETIME
+			rt->rt_acquired = or->rt_acquired;
+#endif
 		}
+
 		rb_tree_remove_node(&ctx->routes, or);
 		rt_free(or);
 	} else {

--- a/src/route.h
+++ b/src/route.h
@@ -139,9 +139,9 @@ struct rt {
 	rb_node_t rt_tree;
 
 #ifdef HAVE_ROUTE_LIFETIME
-	struct timespec rt_aquired; /* timestamp of aquisition */
-	uint32_t rt_lifetime;	    /* current lifetime of route */
-#define RTLIFETIME_DEV_MAX 2	    /* max deviation for cmp */
+	struct timespec rt_acquired; /* timestamp of acquisition */
+	uint32_t rt_lifetime;	     /* current lifetime of route */
+#define RTLIFETIME_DEV_MAX 2	     /* max deviation for cmp */
 #endif
 };
 


### PR DESCRIPTION
RFC 4861 specifies that router advertisements should be sent no more than once every MIN_DELAY_BETWEEN_RAS (3 seconds). In practice though, there are several ISPs (Comcast, Spectrum, Vodafone) that send out router advertisements at higher rates.

Previously this caused dhcpcd to never update the route until it eventually expired and was removed by the kernel.

This happened because the rt_acquired timestamp was out of sync with the kernel expiry tracking. rt_acquired was updated every time a router advertisement was processed **even when the route wasn't updated in the kernel**. When router advertisements were sent out frequently, rt_acquired was updated frequently, the difference between the old and new rt_acquired values never became great enough for rt_cmp_lifetime to return 1 and the kernel's routing table was never updated.

To fix this, keep the old rt_acquired value iff the kernel's routing table wasn't updated. This ensures that rt_acquired stays in sync with the expiry value in the kernel's routing table.

Closes #681
Cc @squarooticus