### PR TITLE
DHCP6: Mirror the prior DHCP rapid commit fix to DHCPv6

### DIFF
--- a/src/dhcp6.c
+++ b/src/dhcp6.c
@@ -922,7 +922,7 @@ dhcp6_makemessage(struct interface *ifp)
 	}
 
 	if (state->state == DH6S_DISCOVER && !(ctx->options & DHCPCD_TEST) &&
-	    dho_policy_allowed(pg, D6_OPTION_RAPID_COMMIT))
+	    dho_policy_requested(pg, D6_OPTION_RAPID_COMMIT))
 		len += sizeof(o);
 
 	if (m == NULL) {
@@ -1160,7 +1160,7 @@ dhcp6_makemessage(struct interface *ifp)
 	COPYIN(D6_OPTION_ELAPSED, &si_len, sizeof(si_len));
 
 	if (state->state == DH6S_DISCOVER && !(ctx->options & DHCPCD_TEST) &&
-	    dho_policy_allowed(pg, D6_OPTION_RAPID_COMMIT))
+	    dho_policy_requested(pg, D6_OPTION_RAPID_COMMIT))
 		COPYIN1(D6_OPTION_RAPID_COMMIT, 0);
 
 	if (dho_policy_allowed(pg, D6_OPTION_USER_CLASS))
@@ -3542,7 +3542,7 @@ dhcp6_recvif(struct interface *ifp, const char *sfrom, struct dhcp6_message *r,
 		case DH6S_DISCOVER:
 			/* Only accept REPLY in DISCOVER for RAPID_COMMIT.
 			 * Normally we get an ADVERTISE for a DISCOVER. */
-			if (!dho_policy_allowed(pg, D6_OPTION_RAPID_COMMIT) ||
+			if (!dho_policy_requested(pg, D6_OPTION_RAPID_COMMIT) ||
 			    !dhcp6_findmoption(r, len, D6_OPTION_RAPID_COMMIT,
 				NULL)) {
 				valid_op = false;


### PR DESCRIPTION
Fixes #690